### PR TITLE
Read API endpoint from Gradle properties in Debug builds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,9 +77,7 @@ cp scripts/pre-push .git/hooks/pre-push
 
 ## Connecting to Local API
 
-In `app/build.gradle.kts`, swap the debug `buildConfigField` values:
-```kotlin
-buildConfigField("String", "DOMAIN","\"192.168.1.21\"")
-buildConfigField("String", "PORT","\"3000\"")
-buildConfigField("String", "SCHEME","\"http\"")
+The debug `buildConfigField` entries in `app/build.gradle.kts` read `NATEMPLATE_API_DOMAIN`, `NATEMPLATE_API_PORT`, and `NATEMPLATE_API_SCHEME` from the environment (`System.getenv`), falling back to `https://api.nativeapptemplate.com` when unset. Invoke Gradle with:
+```bash
+NATEMPLATE_API_DOMAIN=<your-lan-ip> NATEMPLATE_API_PORT=3000 NATEMPLATE_API_SCHEME=http ./gradlew assembleDebug
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,4 @@ cp scripts/pre-push .git/hooks/pre-push
 
 ## Connecting to Local API
 
-The debug `buildConfigField` entries in `app/build.gradle.kts` read `NATEMPLATE_API_DOMAIN`, `NATEMPLATE_API_PORT`, and `NATEMPLATE_API_SCHEME` from the environment (`System.getenv`), falling back to `https://api.nativeapptemplate.com` when unset. Invoke Gradle with:
-```bash
-NATEMPLATE_API_DOMAIN=<your-lan-ip> NATEMPLATE_API_PORT=3000 NATEMPLATE_API_SCHEME=http ./gradlew assembleDebug
-```
+The debug `buildConfigField` entries in `app/build.gradle.kts` read `NATEMPLATE_API_DOMAIN`, `NATEMPLATE_API_PORT`, and `NATEMPLATE_API_SCHEME` via `project.findProperty(...)` (not `System.getenv` — Android Studio launched from Finder/Dock does not inherit shell env). Set them in `~/.gradle/gradle.properties` (user-global, per-developer); the same config then works from both the terminal and the IDE. Falls back to `https://api.nativeapptemplate.com` when unset. One-off override: `./gradlew -PNATEMPLATE_API_DOMAIN=... assembleDebug`.

--- a/README.md
+++ b/README.md
@@ -121,13 +121,13 @@ To run this app successfully, ensure you have:
 
 ## Running with the NativeAppTemplate-API on localhost
 
-To connect to a local API server, update the following configuration in the build.gradle.kts (Module: app):
+To connect to a local API server, set the `NATEMPLATE_API_*` env vars when invoking Gradle:
 
-```kotlin
-buildConfigField("String", "DOMAIN","\"192.168.1.21\"")
-buildConfigField("String", "PORT","\"3000\"")
-buildConfigField("String", "SCHEME","\"http\"")
+```bash
+NATEMPLATE_API_DOMAIN=<your-lan-ip> NATEMPLATE_API_PORT=3000 NATEMPLATE_API_SCHEME=http ./gradlew assembleDebug
 ```
+
+The debug `buildConfigField` entries in `app/build.gradle.kts` read `NATEMPLATE_API_DOMAIN`, `NATEMPLATE_API_PORT`, and `NATEMPLATE_API_SCHEME` via `System.getenv(...)`, falling back to `https://api.nativeapptemplate.com` when unset. These are evaluated at Gradle configuration time, so Android Studio's built-in run action needs to be launched with the env vars set (or use the Gradle-properties approach as an alternative).
 
 ## Blog
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ To run this app successfully, ensure you have:
 
 ## Running with the NativeAppTemplate-API on localhost
 
-By default the debug build hits the hosted API (`https://api.nativeapptemplate.com`). To point it at a Rails server running on your LAN, add to `~/.gradle/gradle.properties`:
+By default the debug build hits the hosted API (`https://api.nativeapptemplate.com`). To point it at a Rails server running on your LAN, add the following to `~/.gradle/gradle.properties` (here `~` is your user home directory — `/Users/<you>` on macOS, `/home/<you>` on Linux, `C:\Users\<you>` on Windows; create the file if it doesn't exist):
 
 ```
 # Use your LAN IP, or 10.0.2.2 for emulator → host

--- a/README.md
+++ b/README.md
@@ -124,7 +124,8 @@ To run this app successfully, ensure you have:
 By default the debug build hits the hosted API (`https://api.nativeapptemplate.com`). To point it at a Rails server running on your LAN, add to `~/.gradle/gradle.properties`:
 
 ```
-NATEMPLATE_API_DOMAIN=192.168.1.6   # LAN IP, or 10.0.2.2 for emulator → host
+# Use your LAN IP, or 10.0.2.2 for emulator → host
+NATEMPLATE_API_DOMAIN=192.168.1.6
 NATEMPLATE_API_PORT=3000
 NATEMPLATE_API_SCHEME=http
 ```

--- a/README.md
+++ b/README.md
@@ -126,12 +126,12 @@ By default the debug build hits the hosted API (`https://api.nativeapptemplate.c
 ```
 # Use your current Wi-Fi IP (macOS: `ipconfig getifaddr en0`), or 10.0.2.2 for emulator → host.
 # Never use 127.0.0.1, localhost, or 0.0.0.0 — Rails and this app must agree on one reachable address.
-NATEMPLATE_API_DOMAIN=192.168.1.6
+NATEMPLATE_API_DOMAIN=192.168.1.21
 NATEMPLATE_API_PORT=3000
 NATEMPLATE_API_SCHEME=http
 ```
 
-Then `./gradlew assembleDebug` — or Build → Rebuild Project from Android Studio. The debug `buildConfigField` entries in `app/build.gradle.kts` read these via `project.findProperty(...)`, so the same config works from both the terminal and the IDE. Remove the three properties to fall back to the hosted default. For a one-off override: `./gradlew -PNATEMPLATE_API_DOMAIN=192.168.1.6 -PNATEMPLATE_API_PORT=3000 -PNATEMPLATE_API_SCHEME=http assembleDebug`.
+Then `./gradlew assembleDebug` — or Build → Rebuild Project from Android Studio. The debug `buildConfigField` entries in `app/build.gradle.kts` read these via `project.findProperty(...)`, so the same config works from both the terminal and the IDE. Remove the three properties to fall back to the hosted default. For a one-off override: `./gradlew -PNATEMPLATE_API_DOMAIN=192.168.1.21 -PNATEMPLATE_API_PORT=3000 -PNATEMPLATE_API_SCHEME=http assembleDebug`.
 
 Cleartext HTTP to private IPs is already permitted in debug via `app/src/debug/res/xml/network_security_config.xml`; the release config (in `app/src/main/`) keeps `api.nativeapptemplate.com` HTTPS-only.
 

--- a/README.md
+++ b/README.md
@@ -121,13 +121,17 @@ To run this app successfully, ensure you have:
 
 ## Running with the NativeAppTemplate-API on localhost
 
-To connect to a local API server, set the `NATEMPLATE_API_*` env vars when invoking Gradle:
+By default the debug build hits the hosted API (`https://api.nativeapptemplate.com`). To point it at a Rails server running on your LAN, add to `~/.gradle/gradle.properties`:
 
-```bash
-NATEMPLATE_API_DOMAIN=<your-lan-ip> NATEMPLATE_API_PORT=3000 NATEMPLATE_API_SCHEME=http ./gradlew assembleDebug
+```
+NATEMPLATE_API_DOMAIN=192.168.1.6   # LAN IP, or 10.0.2.2 for emulator → host
+NATEMPLATE_API_PORT=3000
+NATEMPLATE_API_SCHEME=http
 ```
 
-The debug `buildConfigField` entries in `app/build.gradle.kts` read `NATEMPLATE_API_DOMAIN`, `NATEMPLATE_API_PORT`, and `NATEMPLATE_API_SCHEME` via `System.getenv(...)`, falling back to `https://api.nativeapptemplate.com` when unset. These are evaluated at Gradle configuration time, so Android Studio's built-in run action needs to be launched with the env vars set (or use the Gradle-properties approach as an alternative).
+Then `./gradlew assembleDebug` — or Build → Rebuild Project from Android Studio. The debug `buildConfigField` entries in `app/build.gradle.kts` read these via `project.findProperty(...)`, so the same config works from both the terminal and the IDE. Remove the three properties to fall back to the hosted default. For a one-off override: `./gradlew -PNATEMPLATE_API_DOMAIN=192.168.1.6 -PNATEMPLATE_API_PORT=3000 -PNATEMPLATE_API_SCHEME=http assembleDebug`.
+
+Cleartext HTTP to LAN IPs is already permitted in debug via `app/src/debug/res/xml/network_security_config.xml`; the release config (in `app/src/main/`) keeps `api.nativeapptemplate.com` HTTPS-only.
 
 ## Blog
 

--- a/README.md
+++ b/README.md
@@ -121,10 +121,11 @@ To run this app successfully, ensure you have:
 
 ## Running with the NativeAppTemplate-API on localhost
 
-By default the debug build hits the hosted API (`https://api.nativeapptemplate.com`). To point it at a Rails server running on your LAN, add the following to `~/.gradle/gradle.properties` (here `~` is your user home directory — `/Users/<you>` on macOS, `/home/<you>` on Linux, `C:\Users\<you>` on Windows; create the file if it doesn't exist):
+By default the debug build hits the hosted API (`https://api.nativeapptemplate.com`). To point it at a Rails server running on your Wi-Fi, add the following to `~/.gradle/gradle.properties` (here `~` is your user home directory — `/Users/<you>` on macOS, `/home/<you>` on Linux, `C:\Users\<you>` on Windows; create the file if it doesn't exist):
 
 ```
-# Use your LAN IP, or 10.0.2.2 for emulator → host
+# Use your current Wi-Fi IP (macOS: `ipconfig getifaddr en0`), or 10.0.2.2 for emulator → host.
+# Never use 127.0.0.1, localhost, or 0.0.0.0 — Rails and this app must agree on one reachable address.
 NATEMPLATE_API_DOMAIN=192.168.1.6
 NATEMPLATE_API_PORT=3000
 NATEMPLATE_API_SCHEME=http
@@ -132,7 +133,7 @@ NATEMPLATE_API_SCHEME=http
 
 Then `./gradlew assembleDebug` — or Build → Rebuild Project from Android Studio. The debug `buildConfigField` entries in `app/build.gradle.kts` read these via `project.findProperty(...)`, so the same config works from both the terminal and the IDE. Remove the three properties to fall back to the hosted default. For a one-off override: `./gradlew -PNATEMPLATE_API_DOMAIN=192.168.1.6 -PNATEMPLATE_API_PORT=3000 -PNATEMPLATE_API_SCHEME=http assembleDebug`.
 
-Cleartext HTTP to LAN IPs is already permitted in debug via `app/src/debug/res/xml/network_security_config.xml`; the release config (in `app/src/main/`) keeps `api.nativeapptemplate.com` HTTPS-only.
+Cleartext HTTP to private IPs is already permitted in debug via `app/src/debug/res/xml/network_security_config.xml`; the release config (in `app/src/main/`) keeps `api.nativeapptemplate.com` HTTPS-only.
 
 ## Blog
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -27,7 +27,7 @@ android {
       extra["alwaysUpdateBuildId"] = false
       isDebuggable = true
       buildConfigField("String", "DOMAIN", "\"${(project.findProperty("NATEMPLATE_API_DOMAIN") as String?)?.trim() ?: "api.nativeapptemplate.com"}\"")
-      buildConfigField("String", "PORT",   "\"${(project.findProperty("NATEMPLATE_API_PORT")   as String?)?.trim() ?: ""}\"")
+      buildConfigField("String", "PORT", "\"${(project.findProperty("NATEMPLATE_API_PORT") as String?)?.trim() ?: ""}\"")
       buildConfigField("String", "SCHEME", "\"${(project.findProperty("NATEMPLATE_API_SCHEME") as String?)?.trim() ?: "https"}\"")
     }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -26,9 +26,9 @@ android {
     debug {
       extra["alwaysUpdateBuildId"] = false
       isDebuggable = true
-      buildConfigField("String", "DOMAIN", "\"${(project.findProperty("NATEMPLATE_API_DOMAIN") as String?) ?: "api.nativeapptemplate.com"}\"")
-      buildConfigField("String", "PORT",   "\"${(project.findProperty("NATEMPLATE_API_PORT")   as String?) ?: ""}\"")
-      buildConfigField("String", "SCHEME", "\"${(project.findProperty("NATEMPLATE_API_SCHEME") as String?) ?: "https"}\"")
+      buildConfigField("String", "DOMAIN", "\"${(project.findProperty("NATEMPLATE_API_DOMAIN") as String?)?.trim() ?: "api.nativeapptemplate.com"}\"")
+      buildConfigField("String", "PORT",   "\"${(project.findProperty("NATEMPLATE_API_PORT")   as String?)?.trim() ?: ""}\"")
+      buildConfigField("String", "SCHEME", "\"${(project.findProperty("NATEMPLATE_API_SCHEME") as String?)?.trim() ?: "https"}\"")
     }
 
     release {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -26,12 +26,9 @@ android {
     debug {
       extra["alwaysUpdateBuildId"] = false
       isDebuggable = true
-      buildConfigField("String", "DOMAIN", "\"api.nativeapptemplate.com\"")
-      buildConfigField("String", "PORT", "\"\"")
-      buildConfigField("String", "SCHEME", "\"https\"")
-//      buildConfigField("String", "DOMAIN","\"192.168.1.21\"")
-//      buildConfigField("String", "PORT","\"3000\"")
-//      buildConfigField("String", "SCHEME","\"http\"")
+      buildConfigField("String", "DOMAIN", "\"${System.getenv("NATEMPLATE_API_DOMAIN") ?: "api.nativeapptemplate.com"}\"")
+      buildConfigField("String", "PORT",   "\"${System.getenv("NATEMPLATE_API_PORT")   ?: ""}\"")
+      buildConfigField("String", "SCHEME", "\"${System.getenv("NATEMPLATE_API_SCHEME") ?: "https"}\"")
     }
 
     release {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -26,9 +26,9 @@ android {
     debug {
       extra["alwaysUpdateBuildId"] = false
       isDebuggable = true
-      buildConfigField("String", "DOMAIN", "\"${System.getenv("NATEMPLATE_API_DOMAIN") ?: "api.nativeapptemplate.com"}\"")
-      buildConfigField("String", "PORT",   "\"${System.getenv("NATEMPLATE_API_PORT")   ?: ""}\"")
-      buildConfigField("String", "SCHEME", "\"${System.getenv("NATEMPLATE_API_SCHEME") ?: "https"}\"")
+      buildConfigField("String", "DOMAIN", "\"${(project.findProperty("NATEMPLATE_API_DOMAIN") as String?) ?: "api.nativeapptemplate.com"}\"")
+      buildConfigField("String", "PORT",   "\"${(project.findProperty("NATEMPLATE_API_PORT")   as String?) ?: ""}\"")
+      buildConfigField("String", "SCHEME", "\"${(project.findProperty("NATEMPLATE_API_SCHEME") as String?) ?: "https"}\"")
     }
 
     release {


### PR DESCRIPTION
## Summary
- Debug `buildConfigField` entries in `app/build.gradle.kts` now read `NATEMPLATE_API_DOMAIN`, `NATEMPLATE_API_PORT`, `NATEMPLATE_API_SCHEME` via `project.findProperty(...)` (with `.trim()` to swallow stray whitespace), falling back to the hosted production values when unset.
- Uses `project.findProperty` rather than `System.getenv` so the same config works from both the terminal and Android Studio — Studio launched from Finder/Dock does not inherit shell env, which previously caused the debug build to silently fall back to the hosted API.
- Prefix is `NATEMPLATE_API_*` to avoid collision with the widely-used `API_*` namespace (`API_KEY`, `API_URL`, `API_TOKEN`).
- Release builds are unchanged and always hit `https://api.nativeapptemplate.com`.
- `README.md` and `CLAUDE.md` updated to document the `~/.gradle/gradle.properties` workflow (with `-P` override for one-offs).

## Test plan
- [ ] Add the three `NATEMPLATE_API_*` keys to `~/.gradle/gradle.properties`, run `./gradlew assembleDebug`, confirm `BuildConfig.DOMAIN` in `app/build/generated/source/buildConfig/debug/**/BuildConfig.java` matches
- [ ] Open Android Studio from Finder/Dock, Build → Rebuild, confirm `BuildConfig.DOMAIN` matches the same value (this is the regression the PR targets)
- [ ] One-off override: `./gradlew -PNATEMPLATE_API_DOMAIN=... -PNATEMPLATE_API_PORT=... -PNATEMPLATE_API_SCHEME=... assembleDebug` produces the expected `BuildConfig`
- [ ] With no properties set, Debug build falls back to `https://api.nativeapptemplate.com`
- [ ] Release build always uses the hosted defaults
- [ ] Debug build connects to a LAN `http://<lan-ip>:3000` (cleartext permitted via the existing `app/src/debug/res/xml/network_security_config.xml`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)