### PR TITLE
Rename Number Tag labels to Item Tag for identifier alignment

### DIFF
--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/ShopSettingsView.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/ShopSettingsView.kt
@@ -253,14 +253,14 @@ private fun ShopSettingsContentView(
           ListItem(
             headlineContent = {
               Text(
-                stringResource(R.string.label_shop_settings_manage_number_tags),
+                stringResource(R.string.label_shop_settings_manage_item_tags),
                 style = MaterialTheme.typography.titleMedium,
               )
             },
             leadingContent = {
               Icon(
                 Icons.Outlined.Rectangle,
-                contentDescription = stringResource(R.string.label_shop_settings_manage_number_tags),
+                contentDescription = stringResource(R.string.label_shop_settings_manage_item_tags),
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
               )
             },

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/item_tag_detail/ItemTagEditView.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/item_tag_detail/ItemTagEditView.kt
@@ -144,7 +144,7 @@ fun ItemTagEditContentView(
         supportingText = {
           Column {
             Text(
-              text = "Tag Number must be a 2-${uiState.maximumQueueNumberLength} alphanumeric characters.",
+              text = "Name must be a 2-${uiState.maximumQueueNumberLength} alphanumeric characters.",
               style = MaterialTheme.typography.bodyLarge,
               color = MaterialTheme.colorScheme.onSurfaceVariant,
             )

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/item_tag_list/ItemTagCreateView.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/item_tag_list/ItemTagCreateView.kt
@@ -144,7 +144,7 @@ fun ItemTagCreateContentView(
         supportingText = {
           Column {
             Text(
-              text = "Tag Number must be a 2-${uiState.maximumQueueNumberLength} alphanumeric characters.",
+              text = "Name must be a 2-${uiState.maximumQueueNumberLength} alphanumeric characters.",
               style = MaterialTheme.typography.bodyLarge,
               color = MaterialTheme.colorScheme.onSurfaceVariant,
             )

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/item_tag_list/ItemTagListView.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/item_tag_list/ItemTagListView.kt
@@ -263,7 +263,7 @@ private fun TopAppBar(
       containerColor = MaterialTheme.colorScheme.primaryContainer,
       titleContentColor = MaterialTheme.colorScheme.primary,
     ),
-    title = { Text(stringResource(R.string.label_shop_settings_manage_number_tags)) },
+    title = { Text(stringResource(R.string.label_shop_settings_manage_item_tags)) },
     navigationIcon = {
       IconButton(onClick = {
         onBackClick()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -107,16 +107,16 @@
 
   <string name="label_shop_settings">Shop Settings</string>
   <string name="label_shop_settings_basic_settings">Basic Settings</string>
-  <string name="label_shop_settings_manage_number_tags">Manage Number Tags</string>
+  <string name="label_shop_settings_manage_item_tags">Manage Item Tags</string>
   <string name="label_shop_settings_number_tags_webpage">Number Tags Webpage</string>
   <string name="reset_number_tags_description">Reset all number tag statuses.</string>
   <string name="message_shop_reset">All number tags reset.</string>
 
   <!-- Item Tag -->
-  <string name="tag_number">Tag Number</string>
+  <string name="tag_number">Name</string>
   <string name="label_add_tag">Add Tag</string>
-  <string name="add_tag_description">Add a new number tag and start changing the tag status.</string>
-  <string name="tag_number_is_invalid">Tag number is invalid.</string>
+  <string name="add_tag_description">Add a new item tag and start changing the tag status.</string>
+  <string name="tag_number_is_invalid">Item tag name is invalid.</string>
   <string name="write_server_tag">Write Server Tag</string>
   <string name="write_customer_tag">Write Customer Tag</string>
   <string name="zero_padding">Zero padding(e.g. 07).</string>


### PR DESCRIPTION
## Summary
- Free-Android port of [nativeapptemplate/NativeAppTemplate-Android#37](https://github.com/nativeapptemplate/NativeAppTemplate-Android/pull/37).
- Aligns UI labels with the `ItemTag` identifier (Phase 2 pre-step), so future humanize-based string-literal rename logic (Phase 6) can rewrite them consistently.
- Renames in-scope generic labels only; queue-specific strings (`swipe_number_tag_below`, `server_number_tags_webpage*`, `reset_number_tags*`, `onboarding_description*`, `complete_scan_help`, `show_tag_info_scan_help`) are intentionally kept — they'll be deleted alongside NFC/scan/reset code in Phase 2 Part A.
- Also renames resource identifier `R.string.label_shop_settings_manage_number_tags` → `R.string.label_shop_settings_manage_item_tags` and updates its 3 callers.

### Label changes (`app/src/main/res/values/strings.xml`)
- `Manage Number Tags` → `Manage Item Tags`
- `Tag Number` → `Name` (aligns with `ItemTag.name` after Phase 1 API refactor)
- `Add a new number tag…` → `Add a new item tag…`
- `Tag number is invalid.` → `Item tag name is invalid.`
- Direct literals in `ItemTagCreateView`/`ItemTagEditView` supporting text: `Tag Number must be a 2-N alphanumeric characters.` → `Name must be a 2-N alphanumeric characters.`

## Test plan
- [x] `./gradlew assembleDebug` succeeds (verified locally: `BUILD SUCCESSFUL`)
- [x] `./gradlew test` passes (verified locally: `BUILD SUCCESSFUL`)
- [ ] Manual UI check: Shop Settings shows `Manage Item Tags`; ItemTag list title shows `Manage Item Tags`
- [ ] Manual UI check: ItemTag Create/Edit field header shows `Name`, supporting text shows `Name must be a 2-N alphanumeric characters.` and `Item tag name is invalid.` on invalid input
- [x] `grep -rn "Number Tag" --include="*.kt" --include="*.xml"` in source returns only out-of-scope queue/scan/onboarding entries in `strings.xml`
- [x] `grep -rn "Tag Number" --include="*.kt" --include="*.xml"` in source returns nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)