### PR TITLE
Phase 2A-3: Generic CRUD UI for ItemTag

### DIFF
--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/NatConstants.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/NatConstants.kt
@@ -9,6 +9,7 @@ object NatConstants {
   const val TERMS_OF_USE_URL: String = "https://nativeapptemplate.com/terms"
 
   const val MINIMUM_PASSWORD_LENGTH: Int = 8
+  const val MAXIMUM_ITEM_TAG_DESCRIPTION_LENGTH: Int = 1_000
 
   const val PLACEHOLDER_FULLNAME: String = "John Smith"
   const val PLACEHOLDER_EMAIL: String = "you@example.com"

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/data/login/LoginRepository.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/data/login/LoginRepository.kt
@@ -56,5 +56,5 @@ interface LoginRepository {
 
   fun didShowTapShopBelowTip(): Flow<Boolean>
 
-  fun getMaximumQueueNumberLength(): Flow<Int>
+  fun getMaximumNameLength(): Flow<Int>
 }

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/data/login/LoginRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/data/login/LoginRepositoryImpl.kt
@@ -128,5 +128,5 @@ class LoginRepositoryImpl @Inject constructor(
 
   override fun didShowTapShopBelowTip(): Flow<Boolean> = natPreferencesDataSource.didShowTapShopBelowTip()
 
-  override fun getMaximumQueueNumberLength(): Flow<Int> = natPreferencesDataSource.getMaximumQueueNumberLength()
+  override fun getMaximumNameLength(): Flow<Int> = natPreferencesDataSource.getMaximumNameLength()
 }

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/datastore/NatPreferencesDataSource.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/datastore/NatPreferencesDataSource.kt
@@ -50,7 +50,7 @@ class NatPreferencesDataSource @Inject constructor(
         androidAppVersion = it.androidAppVersion,
         shouldUpdatePrivacy = it.shouldUpdatePrivacy,
         shouldUpdateTerms = it.shouldUpdateTerms,
-        maximumQueueNumberLength = it.maximumQueueNumberLength,
+        maximumNameLength = it.maximumNameLength,
         shopLimitCount = it.shopLimitCount,
 
         isEmailUpdated = it.isEmailUpdated,
@@ -109,7 +109,7 @@ class NatPreferencesDataSource @Inject constructor(
 
           this.shouldUpdatePrivacy = permissions.getShouldUpdatePrivacy()!!
           this.shouldUpdateTerms = permissions.getShouldUpdateTerms()!!
-          this.maximumQueueNumberLength = permissions.getMaximumQueueNumberLength()!!
+          this.maximumNameLength = permissions.getMaximumNameLength()!!
           this.shopLimitCount = permissions.getShopLimitCount()!!
         }
       }
@@ -245,8 +245,8 @@ class NatPreferencesDataSource @Inject constructor(
       data.didShowTapShopBelowTip
     }
 
-  fun getMaximumQueueNumberLength(): Flow<Int> = userPreferences.data
+  fun getMaximumNameLength(): Flow<Int> = userPreferences.data
     .map { data ->
-      data.maximumQueueNumberLength
+      data.maximumNameLength
     }
 }

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_detail/ShopDetailCardView.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_detail/ShopDetailCardView.kt
@@ -16,7 +16,7 @@ import com.nativeapptemplate.nativeapptemplatefree.model.Data
 import com.nativeapptemplate.nativeapptemplatefree.model.ItemTagState
 import com.nativeapptemplate.nativeapptemplatefree.ui.common.tags.CompletedTag
 import com.nativeapptemplate.nativeapptemplatefree.ui.common.tags.IdlingTag
-import com.nativeapptemplate.nativeapptemplatefree.utils.DateUtility.cardTimeString
+import com.nativeapptemplate.nativeapptemplatefree.utils.DateUtility.cardDateTimeString
 
 @Composable
 fun ShopDetailCardView(
@@ -50,7 +50,7 @@ fun ShopDetailCardView(
             CompletedTag()
 
             Text(
-              completedAt.cardTimeString(),
+              completedAt.cardDateTimeString(),
               color = MaterialTheme.colorScheme.onSurfaceVariant,
               modifier = Modifier
                 .padding(top = 4.dp),

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/item_tag_detail/ItemTagDetailView.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/item_tag_detail/ItemTagDetailView.kt
@@ -3,6 +3,7 @@ package com.nativeapptemplate.nativeapptemplatefree.ui.shop_settings.item_tag_de
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -31,17 +32,22 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.nativeapptemplate.nativeapptemplatefree.R
+import com.nativeapptemplate.nativeapptemplatefree.model.ItemTag
+import com.nativeapptemplate.nativeapptemplatefree.model.ItemTagState
 import com.nativeapptemplate.nativeapptemplatefree.ui.common.ErrorView
 import com.nativeapptemplate.nativeapptemplatefree.ui.common.LoadingView
+import com.nativeapptemplate.nativeapptemplatefree.ui.common.MainButtonView
 import com.nativeapptemplate.nativeapptemplatefree.ui.common.NatAlertDialog
 import com.nativeapptemplate.nativeapptemplatefree.ui.common.SnackbarMessageEffect
+import com.nativeapptemplate.nativeapptemplatefree.ui.common.tags.CompletedTag
+import com.nativeapptemplate.nativeapptemplatefree.ui.common.tags.IdlingTag
+import com.nativeapptemplate.nativeapptemplatefree.utils.DateUtility.cardDateTimeString
 
 @Composable
 internal fun ItemTagDetailView(
@@ -158,46 +164,106 @@ private fun ItemTagDetailContentView(
         .padding(padding),
     ) {
       Column(
-        verticalArrangement = Arrangement.spacedBy(12.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
         modifier = Modifier
           .padding(horizontal = 16.dp, vertical = 16.dp)
           .verticalScroll(rememberScrollState()),
       ) {
-        Text(
-          uiState.itemTag.getName(),
-          style = MaterialTheme.typography.titleLarge,
-          color = MaterialTheme.colorScheme.primary,
-          textAlign = TextAlign.Center,
-          modifier = Modifier.fillMaxWidth(),
-        )
-
-        Text(
-          uiState.itemTag.getDescription(),
-          style = MaterialTheme.typography.bodyMedium,
-          textAlign = TextAlign.Center,
-          modifier = Modifier.fillMaxWidth(),
-        )
-
-        Text(
-          uiState.itemTag.getState(),
-          style = MaterialTheme.typography.bodyMedium,
-          color = MaterialTheme.colorScheme.onSurfaceVariant,
-          textAlign = TextAlign.Center,
-          modifier = Modifier.fillMaxWidth(),
-        )
-
-        uiState.itemTag.getCompletedAt()?.takeIf { it.isNotBlank() }?.let { completedAt ->
-          Text(
-            completedAt,
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            textAlign = TextAlign.Center,
-            modifier = Modifier.fillMaxWidth(),
-          )
-        }
+        HeaderRow(itemTag = uiState.itemTag)
+        DescriptionSection(description = uiState.itemTag.getDescription())
+        CompletedAtRow(itemTag = uiState.itemTag)
+        StateToggleButton(viewModel = viewModel, uiState = uiState)
       }
     }
   }
+}
+
+@Composable
+private fun HeaderRow(itemTag: ItemTag) {
+  Row(
+    horizontalArrangement = Arrangement.spacedBy(12.dp),
+    verticalAlignment = Alignment.CenterVertically,
+    modifier = Modifier.fillMaxWidth(),
+  ) {
+    Text(
+      itemTag.getName(),
+      style = MaterialTheme.typography.titleLarge,
+      color = MaterialTheme.colorScheme.primary,
+      modifier = Modifier.weight(1f),
+    )
+
+    when (itemTag.getData()?.getItemTagState()) {
+      ItemTagState.Completed -> CompletedTag()
+      ItemTagState.Idled -> IdlingTag()
+      null -> Unit
+    }
+  }
+}
+
+@Composable
+private fun DescriptionSection(description: String) {
+  if (description.isBlank()) return
+  Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+    Text(
+      stringResource(R.string.description_label),
+      style = MaterialTheme.typography.titleSmall,
+      color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+    Text(
+      description,
+      style = MaterialTheme.typography.bodyMedium,
+    )
+  }
+}
+
+@Composable
+private fun CompletedAtRow(itemTag: ItemTag) {
+  if (itemTag.getData()?.getItemTagState() != ItemTagState.Completed) return
+  val completedAt = itemTag.getCompletedAt()
+  if (completedAt.isNullOrBlank()) return
+
+  Row(
+    horizontalArrangement = Arrangement.spacedBy(8.dp),
+    modifier = Modifier.fillMaxWidth(),
+  ) {
+    Text(
+      stringResource(R.string.completed_at_label),
+      style = MaterialTheme.typography.titleSmall,
+      color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+    Text(
+      completedAt.cardDateTimeString(),
+      style = MaterialTheme.typography.bodyMedium,
+    )
+  }
+}
+
+@Composable
+private fun StateToggleButton(
+  viewModel: ItemTagDetailViewModel,
+  uiState: ItemTagDetailUiState,
+) {
+  val state = uiState.itemTag.getData()?.getItemTagState() ?: return
+
+  val title = when (state) {
+    ItemTagState.Idled -> stringResource(R.string.mark_as_completed)
+    ItemTagState.Completed -> stringResource(R.string.mark_as_idled)
+  }
+  val onClick: () -> Unit = when (state) {
+    ItemTagState.Idled -> viewModel::completeItemTag
+    ItemTagState.Completed -> viewModel::idleItemTag
+  }
+
+  MainButtonView(
+    title = title,
+    onClick = onClick,
+    enabled = !uiState.isToggling,
+    color = MaterialTheme.colorScheme.primary,
+    titleColor = MaterialTheme.colorScheme.primary,
+    modifier = Modifier
+      .fillMaxWidth()
+      .padding(top = 16.dp),
+  )
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/item_tag_detail/ItemTagDetailViewModel.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/item_tag_detail/ItemTagDetailViewModel.kt
@@ -24,6 +24,7 @@ data class ItemTagDetailUiState(
   val isDeleted: Boolean = false,
 
   val isLoading: Boolean = true,
+  val isToggling: Boolean = false,
   val success: Boolean = false,
   val message: String = "",
 )
@@ -101,6 +102,58 @@ class ItemTagDetailViewModel @Inject constructor(
           _uiState.update {
             it.copy(
               isDeleted = true,
+            )
+          }
+        }
+    }
+  }
+
+  fun completeItemTag() {
+    _uiState.update { it.copy(isToggling = true) }
+
+    viewModelScope.launch {
+      val itemTagFlow: Flow<ItemTag> = itemTagRepository.completeItemTag(itemTagId)
+
+      itemTagFlow
+        .catch { exception ->
+          _uiState.update {
+            it.copy(
+              message = exception.codedDescription,
+              isToggling = false,
+            )
+          }
+        }
+        .collect { itemTag ->
+          _uiState.update {
+            it.copy(
+              itemTag = itemTag,
+              isToggling = false,
+            )
+          }
+        }
+    }
+  }
+
+  fun idleItemTag() {
+    _uiState.update { it.copy(isToggling = true) }
+
+    viewModelScope.launch {
+      val itemTagFlow: Flow<ItemTag> = itemTagRepository.idleItemTag(itemTagId)
+
+      itemTagFlow
+        .catch { exception ->
+          _uiState.update {
+            it.copy(
+              message = exception.codedDescription,
+              isToggling = false,
+            )
+          }
+        }
+        .collect { itemTag ->
+          _uiState.update {
+            it.copy(
+              itemTag = itemTag,
+              isToggling = false,
             )
           }
         }

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/item_tag_detail/ItemTagEditView.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/item_tag_detail/ItemTagEditView.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -33,12 +32,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.nativeapptemplate.nativeapptemplatefree.NatConstants
 import com.nativeapptemplate.nativeapptemplatefree.R
 import com.nativeapptemplate.nativeapptemplatefree.ui.common.ErrorView
 import com.nativeapptemplate.nativeapptemplatefree.ui.common.LoadingView
@@ -135,32 +134,53 @@ fun ItemTagEditContentView(
       OutlinedTextField(
         label = {
           Text(
-            text = stringResource(R.string.tag_number),
+            text = stringResource(R.string.name_label),
           )
         },
-        placeholder = { Text("A001") },
+        placeholder = { Text(stringResource(R.string.item_tag_name_placeholder)) },
         value = uiState.name,
         onValueChange = { viewModel.updateName(it) },
         supportingText = {
           Column {
             Text(
-              text = "Name must be a 2-${uiState.maximumQueueNumberLength} alphanumeric characters.",
+              text = stringResource(R.string.item_tag_name_help, uiState.maximumNameLength),
               style = MaterialTheme.typography.bodyLarge,
               color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
             Text(
-              text = stringResource(R.string.zero_padding),
-              style = MaterialTheme.typography.bodyLarge,
-              color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            Text(
-              text = stringResource(id = R.string.tag_number_is_invalid),
+              text = stringResource(R.string.item_tag_name_is_invalid),
               style = MaterialTheme.typography.bodyLarge,
               color = if (viewModel.hasInvalidDataName()) Color.Red else Color.Transparent,
             )
           }
         },
-        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Ascii),
+        modifier = Modifier
+          .fillMaxWidth(),
+      )
+
+      OutlinedTextField(
+        label = {
+          Text(
+            text = stringResource(R.string.description_label),
+          )
+        },
+        value = uiState.description,
+        onValueChange = { viewModel.updateDescription(it) },
+        minLines = 4,
+        supportingText = {
+          Column {
+            Text(
+              text = stringResource(R.string.item_tag_description_help, NatConstants.MAXIMUM_ITEM_TAG_DESCRIPTION_LENGTH),
+              style = MaterialTheme.typography.bodyLarge,
+              color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+              text = stringResource(R.string.item_tag_description_is_invalid),
+              style = MaterialTheme.typography.bodyLarge,
+              color = if (viewModel.hasInvalidDataDescription()) Color.Red else Color.Transparent,
+            )
+          }
+        },
         modifier = Modifier
           .fillMaxWidth(),
       )

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/item_tag_detail/ItemTagEditViewModel.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/item_tag_detail/ItemTagEditViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
+import com.nativeapptemplate.nativeapptemplatefree.NatConstants
 import com.nativeapptemplate.nativeapptemplatefree.common.errors.codedDescription
 import com.nativeapptemplate.nativeapptemplatefree.data.item_tag.ItemTagRepository
 import com.nativeapptemplate.nativeapptemplatefree.data.login.LoginRepository
@@ -11,7 +12,6 @@ import com.nativeapptemplate.nativeapptemplatefree.model.ItemTag
 import com.nativeapptemplate.nativeapptemplatefree.model.ItemTagBody
 import com.nativeapptemplate.nativeapptemplatefree.model.ItemTagBodyDetail
 import com.nativeapptemplate.nativeapptemplatefree.ui.shop_settings.navigation.ItemTagEditRoute
-import com.nativeapptemplate.nativeapptemplatefree.utils.Utility
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -27,7 +27,8 @@ data class ItemTagEditUiState(
   val itemTag: ItemTag = ItemTag(),
 
   val name: String = "",
-  val maximumQueueNumberLength: Int = -1,
+  val description: String = "",
+  val maximumNameLength: Int = -1,
   val isUpdated: Boolean = false,
 
   val isLoading: Boolean = true,
@@ -61,14 +62,15 @@ class ItemTagEditViewModel @Inject constructor(
 
     viewModelScope.launch {
       val itemTagFlow: Flow<ItemTag> = itemTagRepository.getItemTag(itemTagId)
-      val maximumQueueNumberLengthFlow = loginRepository.getMaximumQueueNumberLength()
+      val maximumNameLengthFlow = loginRepository.getMaximumNameLength()
 
-      combine(itemTagFlow, maximumQueueNumberLengthFlow) { itemTag, maximumQueueNumberLength ->
+      combine(itemTagFlow, maximumNameLengthFlow) { itemTag, maximumNameLength ->
         _uiState.update {
           it.copy(
             itemTag = itemTag,
             name = itemTag.getName(),
-            maximumQueueNumberLength = maximumQueueNumberLength,
+            description = itemTag.getDescription(),
+            maximumNameLength = maximumNameLength,
             success = true,
             isLoading = false,
           )
@@ -97,6 +99,7 @@ class ItemTagEditViewModel @Inject constructor(
     viewModelScope.launch {
       val itemTagBodyDetail = ItemTagBodyDetail(
         name = uiState.value.name,
+        description = uiState.value.description,
       )
       val itemTagBody = ItemTagBody(itemTagBodyDetail)
 
@@ -126,30 +129,41 @@ class ItemTagEditViewModel @Inject constructor(
 
   fun hasInvalidData(): Boolean {
     if (hasInvalidDataName()) return true
+    if (hasInvalidDataDescription()) return true
 
     val itemTag = uiState.value.itemTag
-    return itemTag.getName() == uiState.value.name
+    val nameUnchanged = itemTag.getName() == uiState.value.name
+    val descriptionUnchanged = itemTag.getDescription() == uiState.value.description
+    return nameUnchanged && descriptionUnchanged
   }
 
   fun hasInvalidDataName(): Boolean {
     val name = uiState.value.name
+    val maximumNameLength = uiState.value.maximumNameLength
 
     if (name.isBlank()) return true
+    if (maximumNameLength <= 0) return false
+    return name.length > maximumNameLength
+  }
 
-    if (!Utility.isAlphanumeric(name)) return true
-
-    if (!(2 <= name.length && name.length <= uiState.value.maximumQueueNumberLength)) {
-      return true
-    }
-
-    return false
+  fun hasInvalidDataDescription(): Boolean {
+    return uiState.value.description.length > NatConstants.MAXIMUM_ITEM_TAG_DESCRIPTION_LENGTH
   }
 
   fun updateName(newName: String) {
-    if (newName.length <= uiState.value.maximumQueueNumberLength) {
-      _uiState.update {
-        it.copy(name = newName)
-      }
+    val maximumNameLength = uiState.value.maximumNameLength
+    if (maximumNameLength > 0 && newName.length > maximumNameLength) return
+
+    _uiState.update {
+      it.copy(name = newName)
+    }
+  }
+
+  fun updateDescription(newDescription: String) {
+    if (newDescription.length > NatConstants.MAXIMUM_ITEM_TAG_DESCRIPTION_LENGTH) return
+
+    _uiState.update {
+      it.copy(description = newDescription)
     }
   }
 

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/item_tag_list/ItemTagCreateView.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/item_tag_list/ItemTagCreateView.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -32,12 +31,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.nativeapptemplate.nativeapptemplatefree.NatConstants
 import com.nativeapptemplate.nativeapptemplatefree.R
 import com.nativeapptemplate.nativeapptemplatefree.ui.common.ErrorView
 import com.nativeapptemplate.nativeapptemplatefree.ui.common.LoadingView
@@ -135,32 +134,53 @@ fun ItemTagCreateContentView(
       OutlinedTextField(
         label = {
           Text(
-            text = stringResource(R.string.tag_number),
+            text = stringResource(R.string.name_label),
           )
         },
-        placeholder = { Text("A001") },
+        placeholder = { Text(stringResource(R.string.item_tag_name_placeholder)) },
         value = uiState.name,
         onValueChange = { viewModel.updateName(it) },
         supportingText = {
           Column {
             Text(
-              text = "Name must be a 2-${uiState.maximumQueueNumberLength} alphanumeric characters.",
+              text = stringResource(R.string.item_tag_name_help, uiState.maximumNameLength),
               style = MaterialTheme.typography.bodyLarge,
               color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
             Text(
-              text = stringResource(R.string.zero_padding),
-              style = MaterialTheme.typography.bodyLarge,
-              color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            Text(
-              text = stringResource(id = R.string.tag_number_is_invalid),
+              text = stringResource(R.string.item_tag_name_is_invalid),
               style = MaterialTheme.typography.bodyLarge,
               color = if (viewModel.hasInvalidDataName()) Color.Red else Color.Transparent,
             )
           }
         },
-        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Ascii),
+        modifier = Modifier
+          .fillMaxWidth(),
+      )
+
+      OutlinedTextField(
+        label = {
+          Text(
+            text = stringResource(R.string.description_label),
+          )
+        },
+        value = uiState.description,
+        onValueChange = { viewModel.updateDescription(it) },
+        minLines = 4,
+        supportingText = {
+          Column {
+            Text(
+              text = stringResource(R.string.item_tag_description_help, NatConstants.MAXIMUM_ITEM_TAG_DESCRIPTION_LENGTH),
+              style = MaterialTheme.typography.bodyLarge,
+              color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+              text = stringResource(R.string.item_tag_description_is_invalid),
+              style = MaterialTheme.typography.bodyLarge,
+              color = if (viewModel.hasInvalidDataDescription()) Color.Red else Color.Transparent,
+            )
+          }
+        },
         modifier = Modifier
           .fillMaxWidth(),
       )

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/item_tag_list/ItemTagCreateViewModel.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/item_tag_list/ItemTagCreateViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
+import com.nativeapptemplate.nativeapptemplatefree.NatConstants
 import com.nativeapptemplate.nativeapptemplatefree.common.errors.codedDescription
 import com.nativeapptemplate.nativeapptemplatefree.data.item_tag.ItemTagRepository
 import com.nativeapptemplate.nativeapptemplatefree.data.login.LoginRepository
@@ -11,7 +12,6 @@ import com.nativeapptemplate.nativeapptemplatefree.model.ItemTag
 import com.nativeapptemplate.nativeapptemplatefree.model.ItemTagBody
 import com.nativeapptemplate.nativeapptemplatefree.model.ItemTagBodyDetail
 import com.nativeapptemplate.nativeapptemplatefree.ui.shop_settings.navigation.ItemTagCreateRoute
-import com.nativeapptemplate.nativeapptemplatefree.utils.Utility
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -24,7 +24,8 @@ import javax.inject.Inject
 
 data class ItemTagCreateUiState(
   val name: String = "",
-  val maximumQueueNumberLength: Int = -1,
+  val description: String = "",
+  val maximumNameLength: Int = -1,
   val isCreated: Boolean = false,
 
   val isLoading: Boolean = true,
@@ -57,9 +58,9 @@ class ItemTagCreateViewModel @Inject constructor(
     }
 
     viewModelScope.launch {
-      val maximumQueueNumberLengthFlow = loginRepository.getMaximumQueueNumberLength()
+      val maximumNameLengthFlow = loginRepository.getMaximumNameLength()
 
-      maximumQueueNumberLengthFlow
+      maximumNameLengthFlow
         .catch { exception ->
           val message = exception.codedDescription
           _uiState.update {
@@ -69,10 +70,10 @@ class ItemTagCreateViewModel @Inject constructor(
             )
           }
         }
-        .collect { maximumQueueNumberLength ->
+        .collect { maximumNameLength ->
           _uiState.update {
             it.copy(
-              maximumQueueNumberLength = maximumQueueNumberLength,
+              maximumNameLength = maximumNameLength,
               success = true,
               isLoading = false,
             )
@@ -92,6 +93,7 @@ class ItemTagCreateViewModel @Inject constructor(
     viewModelScope.launch {
       val itemTagBodyDetail = ItemTagBodyDetail(
         name = uiState.value.name,
+        description = uiState.value.description,
       )
       val itemTagBody = ItemTagBody(itemTagBodyDetail)
 
@@ -118,28 +120,36 @@ class ItemTagCreateViewModel @Inject constructor(
   }
 
   fun hasInvalidData(): Boolean {
-    return hasInvalidDataName()
+    return hasInvalidDataName() || hasInvalidDataDescription()
   }
 
   fun hasInvalidDataName(): Boolean {
     val name = uiState.value.name
+    val maximumNameLength = uiState.value.maximumNameLength
 
     if (name.isBlank()) return true
+    if (maximumNameLength <= 0) return false
+    return name.length > maximumNameLength
+  }
 
-    if (!Utility.isAlphanumeric(name)) return true
-
-    if (!(2 <= name.length && name.length <= uiState.value.maximumQueueNumberLength)) {
-      return true
-    }
-
-    return false
+  fun hasInvalidDataDescription(): Boolean {
+    return uiState.value.description.length > NatConstants.MAXIMUM_ITEM_TAG_DESCRIPTION_LENGTH
   }
 
   fun updateName(newName: String) {
-    if (newName.length <= uiState.value.maximumQueueNumberLength) {
-      _uiState.update {
-        it.copy(name = newName)
-      }
+    val maximumNameLength = uiState.value.maximumNameLength
+    if (maximumNameLength > 0 && newName.length > maximumNameLength) return
+
+    _uiState.update {
+      it.copy(name = newName)
+    }
+  }
+
+  fun updateDescription(newDescription: String) {
+    if (newDescription.length > NatConstants.MAXIMUM_ITEM_TAG_DESCRIPTION_LENGTH) return
+
+    _uiState.update {
+      it.copy(description = newDescription)
     }
   }
 

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/item_tag_list/ItemTagListCardView.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/item_tag_list/ItemTagListCardView.kt
@@ -1,24 +1,75 @@
 package com.nativeapptemplate.nativeapptemplatefree.ui.shop_settings.item_tag_list
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
 import com.nativeapptemplate.nativeapptemplatefree.model.Data
+import com.nativeapptemplate.nativeapptemplatefree.model.ItemTagState
+import com.nativeapptemplate.nativeapptemplatefree.ui.common.tags.CompletedTag
+import com.nativeapptemplate.nativeapptemplatefree.ui.common.tags.IdlingTag
+import com.nativeapptemplate.nativeapptemplatefree.utils.DateUtility.cardDateTimeString
 
 @Composable
 fun ItemTagListCardView(
   data: Data,
   onItemClick: (String) -> Unit,
 ) {
+  val description = data.getDescription()
+  val state = data.getItemTagState()
+  val completedAt = data.getCompletedAt()
+
   ListItem(
     headlineContent = {
-      Text(
-        data.getName(),
-        style = MaterialTheme.typography.titleMedium,
-      )
+      Row(
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.fillMaxWidth(),
+      ) {
+        Text(
+          data.getName(),
+          style = MaterialTheme.typography.titleMedium,
+          modifier = Modifier.weight(1f),
+        )
+        when (state) {
+          ItemTagState.Completed -> CompletedTag()
+          ItemTagState.Idled -> IdlingTag()
+          null -> Unit
+        }
+      }
+    },
+    supportingContent = if (description.isBlank() && state != ItemTagState.Completed) {
+      null
+    } else {
+      {
+        Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+          if (description.isNotBlank()) {
+            Text(
+              description,
+              style = MaterialTheme.typography.bodySmall,
+              maxLines = 2,
+              overflow = TextOverflow.Ellipsis,
+              color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+          }
+          if (state == ItemTagState.Completed && completedAt.isNotBlank()) {
+            Text(
+              completedAt.cardDateTimeString(),
+              style = MaterialTheme.typography.bodySmall,
+              color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+          }
+        }
+      }
     },
     modifier = Modifier
       .clickable {

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/utils/DateTimeFormatterUtility.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/utils/DateTimeFormatterUtility.kt
@@ -3,7 +3,7 @@ package com.nativeapptemplate.nativeapptemplatefree.utils
 import java.time.format.DateTimeFormatter
 
 object DateTimeFormatterUtility {
-  private const val CARD_DATE_STRING: String = "MMM dd yyyy"
+  private const val CARD_DATE_STRING: String = "yyyy/MM/dd"
   private const val CARD_TIME_STRING: String = "HH:mm"
 
   fun cardDateFormatter(): DateTimeFormatter {

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/utils/DateUtility.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/utils/DateUtility.kt
@@ -29,6 +29,17 @@ object DateUtility {
     return date.cardTimeString()
   }
 
+  fun ZonedDateTime.cardDateTimeString(): String {
+    return "${this.cardDateString()} ${this.cardTimeString()}"
+  }
+
+  fun String.cardDateTimeString(zoneId: ZoneId = ZoneId.systemDefault()): String {
+    if (this.isBlank()) return ""
+
+    val date = ZonedDateTime.parse(this).withZoneSameInstant(zoneId)
+    return date.cardDateTimeString()
+  }
+
   fun ZonedDateTime.cardTimeAgoInWordsDateString(): String {
     return DateUtils.getRelativeTimeSpanString(this.toInstant().toEpochMilli(), System.currentTimeMillis(), DateUtils.MINUTE_IN_MILLIS).toString()
   }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -104,11 +104,18 @@
   <string name="label_shop_settings_manage_item_tags">Manage Item Tags</string>
 
   <!-- Item Tag -->
-  <string name="tag_number">Name</string>
+  <string name="name_label">Name</string>
+  <string name="description_label">Description</string>
+  <string name="completed_at_label">Completed at</string>
+  <string name="item_tag_name_placeholder">Buy milk</string>
   <string name="label_add_tag">Add Tag</string>
   <string name="add_tag_description">Add a new item tag and start changing the tag status.</string>
-  <string name="tag_number_is_invalid">Item tag name is invalid.</string>
-  <string name="zero_padding">Zero padding(e.g. 07).</string>
+  <string name="item_tag_name_is_invalid">Tag name is invalid.</string>
+  <string name="item_tag_description_is_invalid">Tag description is invalid.</string>
+  <string name="item_tag_name_help">Name must be 1-%1$d characters.</string>
+  <string name="item_tag_description_help">Description must be 0-%1$d characters.</string>
+  <string name="mark_as_completed">Mark as completed</string>
+  <string name="mark_as_idled">Mark as idled</string>
 
   <string name="message_item_tag_created">Tag created successfully.</string>
   <string name="message_item_tag_updated">Tag updated successfully.</string>

--- a/app/src/test/kotlin/com/nativeapptemplate/nativeapptemplatefree/demo/login/DemoLoginRepository.kt
+++ b/app/src/test/kotlin/com/nativeapptemplate/nativeapptemplatefree/demo/login/DemoLoginRepository.kt
@@ -100,7 +100,7 @@ class DemoLoginRepository @Inject constructor(
 
   override fun didShowTapShopBelowTip(): Flow<Boolean> = MutableStateFlow(true)
 
-  override fun getMaximumQueueNumberLength(): Flow<Int> = MutableStateFlow(5)
+  override fun getMaximumNameLength(): Flow<Int> = MutableStateFlow(100)
 
   @OptIn(ExperimentalSerializationApi::class)
   private suspend inline fun <reified T> getDataFromJsonFile(fileName: String): T =

--- a/app/src/test/kotlin/com/nativeapptemplate/nativeapptemplatefree/testing/repository/TestLoginRepository.kt
+++ b/app/src/test/kotlin/com/nativeapptemplate/nativeapptemplatefree/testing/repository/TestLoginRepository.kt
@@ -134,7 +134,7 @@ class TestLoginRepository : LoginRepository {
 
   override fun didShowTapShopBelowTip(): Flow<Boolean> = MutableStateFlow(true)
 
-  override fun getMaximumQueueNumberLength(): Flow<Int> = userData.map { it.maximumQueueNumberLength }
+  override fun getMaximumNameLength(): Flow<Int> = userData.map { it.maximumNameLength }
 
   /**
    * A test-only API.

--- a/app/src/test/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/item_tag_detail/ItemTagDetailViewModelTest.kt
+++ b/app/src/test/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/item_tag_detail/ItemTagDetailViewModelTest.kt
@@ -83,6 +83,36 @@ class ItemTagDetailViewModelTest {
   }
 
   @Test
+  fun completeItemTag_updatesItemTagAndClearsToggling() = runTest {
+    backgroundScope.launch(UnconfinedTestDispatcher()) { viewModel.uiState.collect() }
+
+    itemTagRepository.sendItemTag(testInputItemTag)
+    viewModel.reload()
+
+    itemTagRepository.sendItemTag(testInputCompletedItemTag)
+    viewModel.completeItemTag()
+
+    val uiStateValue = viewModel.uiState.value
+    assertFalse(uiStateValue.isToggling)
+    assertEquals(testInputCompletedItemTag, uiStateValue.itemTag)
+  }
+
+  @Test
+  fun idleItemTag_updatesItemTagAndClearsToggling() = runTest {
+    backgroundScope.launch(UnconfinedTestDispatcher()) { viewModel.uiState.collect() }
+
+    itemTagRepository.sendItemTag(testInputCompletedItemTag)
+    viewModel.reload()
+
+    itemTagRepository.sendItemTag(testInputItemTag)
+    viewModel.idleItemTag()
+
+    val uiStateValue = viewModel.uiState.value
+    assertFalse(uiStateValue.isToggling)
+    assertEquals(testInputItemTag, uiStateValue.itemTag)
+  }
+
+  @Test
   fun stateMessage_isUpdated() = runTest {
     backgroundScope.launch(UnconfinedTestDispatcher()) { viewModel.uiState.collect() }
 
@@ -125,4 +155,10 @@ private val testInputItemTagData =
 
 private val testInputItemTag = ItemTag(
   datum = testInputItemTagData,
+)
+
+private val testInputCompletedItemTag = ItemTag(
+  datum = testInputItemTagData.copy(
+    attributes = testInputItemTagData.attributes!!.copy(state = "completed"),
+  ),
 )

--- a/app/src/test/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/item_tag_detail/ItemTagEditViewModelTest.kt
+++ b/app/src/test/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/item_tag_detail/ItemTagEditViewModelTest.kt
@@ -61,7 +61,7 @@ class ItemTagEditViewModelTest {
   fun stateItemTag_whenSuccess_matchesItemTagFromRepository() = runTest {
     backgroundScope.launch(UnconfinedTestDispatcher()) { viewModel.uiState.collect() }
 
-    loginRepository.sendUserData(emptyUserData)
+    loginRepository.sendUserData(emptyUserData.copy(maximumNameLength = 100))
     itemTagRepository.sendItemTag((testInputItemTag))
 
     viewModel.reload()
@@ -78,16 +78,16 @@ class ItemTagEditViewModelTest {
   fun stateIsUpdated_whenUpdatingItemTag_becomesTrue() = runTest {
     backgroundScope.launch(UnconfinedTestDispatcher()) { viewModel.uiState.collect() }
 
-    val maximumQueueNumberLength = 5
+    val maximumNameLength = 100
     val userData = emptyUserData.copy(
-      maximumQueueNumberLength = maximumQueueNumberLength,
+      maximumNameLength = maximumNameLength,
     )
 
     loginRepository.sendUserData(userData)
     itemTagRepository.sendItemTag(testInputItemTag)
 
     viewModel.reload()
-    val newName = "Z0001"
+    val newName = "Buy bread"
     viewModel.updateName(newName)
     assertEquals(viewModel.uiState.value.name, newName)
     assertFalse(viewModel.hasInvalidData())
@@ -99,8 +99,37 @@ class ItemTagEditViewModelTest {
   }
 
   @Test
+  fun unchangedNameAndDescription_isInvalid() = runTest {
+    backgroundScope.launch(UnconfinedTestDispatcher()) { viewModel.uiState.collect() }
+
+    loginRepository.sendUserData(emptyUserData.copy(maximumNameLength = 100))
+    itemTagRepository.sendItemTag(testInputItemTag)
+    viewModel.reload()
+
+    // No edits — name and description equal current values
+    assertTrue(viewModel.hasInvalidData())
+  }
+
+  @Test
+  fun changedDescriptionOnly_isValid() = runTest {
+    backgroundScope.launch(UnconfinedTestDispatcher()) { viewModel.uiState.collect() }
+
+    loginRepository.sendUserData(emptyUserData.copy(maximumNameLength = 100))
+    itemTagRepository.sendItemTag(testInputItemTag)
+    viewModel.reload()
+
+    viewModel.updateDescription("a new description")
+
+    assertFalse(viewModel.hasInvalidData())
+  }
+
+  @Test
   fun blankName_isInvalid() = runTest {
     backgroundScope.launch(UnconfinedTestDispatcher()) { viewModel.uiState.collect() }
+
+    loginRepository.sendUserData(emptyUserData.copy(maximumNameLength = 100))
+    itemTagRepository.sendItemTag(testInputItemTag)
+    viewModel.reload()
 
     viewModel.updateName("")
 
@@ -109,23 +138,16 @@ class ItemTagEditViewModelTest {
   }
 
   @Test
-  fun nameWithIncorrectLength_isInvalid() = runTest {
+  fun nameWithSymbolsAndUnicode_isValid() = runTest {
     backgroundScope.launch(UnconfinedTestDispatcher()) { viewModel.uiState.collect() }
 
-    viewModel.updateName("123456")
+    loginRepository.sendUserData(emptyUserData.copy(maximumNameLength = 100))
+    itemTagRepository.sendItemTag(testInputItemTag)
+    viewModel.reload()
 
-    assertTrue(viewModel.hasInvalidDataName())
-    assertTrue(viewModel.hasInvalidData())
-  }
+    viewModel.updateName("Buy milk 🥛 + bread")
 
-  @Test
-  fun wrongFormatName_isInvalid() = runTest {
-    backgroundScope.launch(UnconfinedTestDispatcher()) { viewModel.uiState.collect() }
-
-    viewModel.updateName("@1234")
-
-    assertTrue(viewModel.hasInvalidDataName())
-    assertTrue(viewModel.hasInvalidData())
+    assertFalse(viewModel.hasInvalidDataName())
   }
 }
 

--- a/app/src/test/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/item_tag_list/ItemTagCreateViewModelTest.kt
+++ b/app/src/test/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/item_tag_list/ItemTagCreateViewModelTest.kt
@@ -59,13 +59,13 @@ class ItemTagCreateViewModelTest {
   }
 
   @Test
-  fun stateMaximumQueueNumberLength_whenSuccess_matchesMaximumQueueNumberLengthFromRepository() = runTest {
+  fun stateMaximumNameLength_whenSuccess_matchesMaximumNameLengthFromRepository() = runTest {
     backgroundScope.launch(UnconfinedTestDispatcher()) { viewModel.uiState.collect() }
 
-    val maximumQueueNumberLength = 5
+    val maximumNameLength = 100
 
     val userData = emptyUserData.copy(
-      maximumQueueNumberLength = maximumQueueNumberLength,
+      maximumNameLength = maximumNameLength,
     )
 
     loginRepository.sendUserData(userData)
@@ -75,23 +75,23 @@ class ItemTagCreateViewModelTest {
     assertTrue(uiStateValue.success)
     assertFalse(uiStateValue.isLoading)
 
-    assertEquals(loginRepository.getMaximumQueueNumberLength().first(), maximumQueueNumberLength)
+    assertEquals(loginRepository.getMaximumNameLength().first(), maximumNameLength)
   }
 
   @Test
   fun stateIsCreated_whenCreatingItemTag_becomesTrue() = runTest {
     backgroundScope.launch(UnconfinedTestDispatcher()) { viewModel.uiState.collect() }
 
-    val maximumQueueNumberLength = 5
+    val maximumNameLength = 100
     val userData = emptyUserData.copy(
-      maximumQueueNumberLength = maximumQueueNumberLength,
+      maximumNameLength = maximumNameLength,
     )
 
     loginRepository.sendUserData(userData)
     itemTagRepository.sendItemTag(testInputItemTag)
 
     viewModel.reload()
-    val newName = "A0001"
+    val newName = "Buy milk"
     viewModel.updateName(newName)
     assertEquals(viewModel.uiState.value.name, newName)
     assertFalse(viewModel.hasInvalidData())
@@ -106,6 +106,8 @@ class ItemTagCreateViewModelTest {
   fun blankName_isInvalid() = runTest {
     backgroundScope.launch(UnconfinedTestDispatcher()) { viewModel.uiState.collect() }
 
+    loginRepository.sendUserData(emptyUserData.copy(maximumNameLength = 100))
+    viewModel.reload()
     viewModel.updateName("")
 
     assertTrue(viewModel.hasInvalidDataName())
@@ -113,23 +115,70 @@ class ItemTagCreateViewModelTest {
   }
 
   @Test
-  fun nameWithIncorrectLength_isInvalid() = runTest {
+  fun singleCharacterName_isValid() = runTest {
     backgroundScope.launch(UnconfinedTestDispatcher()) { viewModel.uiState.collect() }
 
-    viewModel.updateName("123456")
+    loginRepository.sendUserData(emptyUserData.copy(maximumNameLength = 100))
+    viewModel.reload()
+    viewModel.updateName("A")
 
-    assertTrue(viewModel.hasInvalidDataName())
-    assertTrue(viewModel.hasInvalidData())
+    assertFalse(viewModel.hasInvalidDataName())
   }
 
   @Test
-  fun wrongFormatName_isInvalid() = runTest {
+  fun nameWithSymbolsAndUnicode_isValid() = runTest {
     backgroundScope.launch(UnconfinedTestDispatcher()) { viewModel.uiState.collect() }
 
-    viewModel.updateName("@1234")
+    loginRepository.sendUserData(emptyUserData.copy(maximumNameLength = 100))
+    viewModel.reload()
+    viewModel.updateName("Buy milk 🥛 + bread")
 
-    assertTrue(viewModel.hasInvalidDataName())
-    assertTrue(viewModel.hasInvalidData())
+    assertFalse(viewModel.hasInvalidDataName())
+  }
+
+  @Test
+  fun nameAtMaximumLength_isValid() = runTest {
+    backgroundScope.launch(UnconfinedTestDispatcher()) { viewModel.uiState.collect() }
+
+    loginRepository.sendUserData(emptyUserData.copy(maximumNameLength = 100))
+    viewModel.reload()
+    viewModel.updateName("A".repeat(100))
+
+    assertFalse(viewModel.hasInvalidDataName())
+  }
+
+  @Test
+  fun nameAboveMaximumLength_isRejectedByUpdater() = runTest {
+    backgroundScope.launch(UnconfinedTestDispatcher()) { viewModel.uiState.collect() }
+
+    loginRepository.sendUserData(emptyUserData.copy(maximumNameLength = 100))
+    viewModel.reload()
+    viewModel.updateName("A".repeat(101))
+
+    // updater clamps; value should remain blank (initial)
+    assertEquals("", viewModel.uiState.value.name)
+  }
+
+  @Test
+  fun descriptionAtMaximumLength_isValid() = runTest {
+    backgroundScope.launch(UnconfinedTestDispatcher()) { viewModel.uiState.collect() }
+
+    loginRepository.sendUserData(emptyUserData.copy(maximumNameLength = 100))
+    viewModel.reload()
+    viewModel.updateDescription("D".repeat(1_000))
+
+    assertFalse(viewModel.hasInvalidDataDescription())
+  }
+
+  @Test
+  fun descriptionAboveMaximumLength_isRejectedByUpdater() = runTest {
+    backgroundScope.launch(UnconfinedTestDispatcher()) { viewModel.uiState.collect() }
+
+    loginRepository.sendUserData(emptyUserData.copy(maximumNameLength = 100))
+    viewModel.reload()
+    viewModel.updateDescription("D".repeat(1_001))
+
+    assertEquals("", viewModel.uiState.value.description)
   }
 }
 

--- a/app/src/test/kotlin/com/nativeapptemplate/nativeapptemplatefree/utils/DateUtilityTest.kt
+++ b/app/src/test/kotlin/com/nativeapptemplate/nativeapptemplatefree/utils/DateUtilityTest.kt
@@ -1,6 +1,7 @@
 package com.nativeapptemplate.nativeapptemplatefree.utils
 
 import com.nativeapptemplate.nativeapptemplatefree.utils.DateUtility.cardDateString
+import com.nativeapptemplate.nativeapptemplatefree.utils.DateUtility.cardDateTimeString
 import com.nativeapptemplate.nativeapptemplatefree.utils.DateUtility.cardTimeString
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -34,6 +35,19 @@ class DateUtilityTest {
   @Test
   fun zonedDateTime_cardTimeString_formatsCorrectly() {
     assertEquals("14:30", testZonedDateTime.cardTimeString())
+  }
+
+  @Test
+  fun zonedDateTime_cardDateTimeString_combinesDateAndTime() {
+    val result = testZonedDateTime.cardDateTimeString()
+    assertTrue(result.contains("15"))
+    assertTrue(result.contains("2025"))
+    assertTrue(result.contains("14:30"))
+  }
+
+  @Test
+  fun string_cardDateTimeString_returnsEmptyForBlankString() {
+    assertEquals("", "".cardDateTimeString())
   }
 
   // String extension tests with UTC zone

--- a/datastore-proto/src/main/proto/user_preferences.proto
+++ b/datastore-proto/src/main/proto/user_preferences.proto
@@ -29,7 +29,7 @@ message UserPreferences {
   int32 android_app_version = 20;
   bool should_update_privacy = 21;
   bool should_update_terms = 22;
-  int32 maximum_queue_number_length = 23;
+  int32 maximum_name_length = 23;
   int32 shop_limit_count = 28;
 
   bool is_email_updated = 32;

--- a/model/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/model/Attributes.kt
+++ b/model/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/model/Attributes.kt
@@ -24,7 +24,7 @@ data class Attributes(
 
   val state: String? = null,
 
-  val position: Int? = null,
+  val position: Int = 0,
 
   @SerialName("completed_at")
   val completedAt: String? = null,

--- a/model/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/model/Data.kt
+++ b/model/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/model/Data.kt
@@ -55,7 +55,7 @@ data class Data(
 
   fun getCurrentAccountName(): String? = attributes?.accountName
 
-  fun getPosition(): Int? = attributes?.position
+  fun getPosition(): Int = attributes?.position ?: 0
 
   fun getCompletedAt(): String = attributes?.completedAt ?: ""
 

--- a/model/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/model/ItemTag.kt
+++ b/model/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/model/ItemTag.kt
@@ -27,7 +27,7 @@ data class ItemTag(
 
   fun getDescription(): String = getData()?.getDescription() ?: ""
 
-  fun getPosition(): Int? = getData()?.getPosition()
+  fun getPosition(): Int = getData()?.getPosition() ?: 0
 
   fun getState(): String = getData()?.getState() ?: ""
 

--- a/model/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/model/ItemTagBodyDetail.kt
+++ b/model/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/model/ItemTagBodyDetail.kt
@@ -9,5 +9,4 @@ import kotlinx.serialization.Serializable
 data class ItemTagBodyDetail(
   val name: String,
   val description: String = "",
-  val position: Int? = null,
 ) : Parcelable

--- a/model/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/model/Meta.kt
+++ b/model/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/model/Meta.kt
@@ -23,8 +23,8 @@ data class Meta(
   @SerialName("should_update_terms")
   var shouldUpdateTerms: Boolean? = null,
 
-  @SerialName("maximum_queue_number_length")
-  var maximumQueueNumberLength: Int = 256,
+  @SerialName("maximum_name_length")
+  var maximumNameLength: Int = 100,
 
   @SerialName("shop_limit_count")
   var shopLimitCount: Int = 0,

--- a/model/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/model/Permissions.kt
+++ b/model/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/model/Permissions.kt
@@ -21,7 +21,7 @@ data class Permissions(
 
   fun getShouldUpdateTerms(): Boolean? = meta?.shouldUpdateTerms
 
-  fun getMaximumQueueNumberLength(): Int? = meta?.maximumQueueNumberLength
+  fun getMaximumNameLength(): Int? = meta?.maximumNameLength
 
   fun getShopLimitCount(): Int? = meta?.shopLimitCount
 }

--- a/model/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/model/UserData.kt
+++ b/model/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/model/UserData.kt
@@ -40,7 +40,7 @@ data class UserData(
   var androidAppVersion: Int = -1,
   var shouldUpdatePrivacy: Boolean = false,
   var shouldUpdateTerms: Boolean = false,
-  var maximumQueueNumberLength: Int = -1,
+  var maximumNameLength: Int = -1,
   var shopLimitCount: Int = -1,
 
   var isEmailUpdated: Boolean = false,


### PR DESCRIPTION
## Summary
Mirrors NativeAppTemplate-Android PR [#40](https://github.com/nativeapptemplate/NativeAppTemplate-Android/pull/40) (which mirrors iOS PR [#50](https://github.com/nativeapptemplate/NativeAppTemplate-iOS/pull/50)). After this sub-phase, ItemTag is a generic parent-child CRUD UI: Create/Edit accept any unicode/symbol name with multi-line description, Detail screen shows a state badge + completed timestamp + Mark-as-completed/idled toggle, the list card surfaces description preview + state. Repository / network plumbing for `complete(id) / idle(id)` reused as-is from #31.

Stacked on top of `substrate-v2`; merge that branch into `main` when ready.

**Differences from the paid PR:** this Free repo has no per-action permission system (`canCreateShops` / `canUpdateShops` / `canDeleteShops` / `canManageTags`), so all permission-gating in views and ViewModels is omitted — the FAB, swipe-delete, edit toolbar, and state-toggle button are always shown.

### Data layer
- `ItemTag.position`: `Int?` → `Int = 0`. Rails server's `set_position_if_missing` always populates this; the client trusts the contract.
- `ItemTagBodyDetail`: dropped `position` (server auto-assigns).
- `Data.getPosition()` / `ItemTag.getPosition()`: now non-null `Int`.

### Rename `maximumQueueNumberLength` → `maximumNameLength`
- `Meta` serial name `maximum_queue_number_length` → `maximum_name_length`; default fallback 256 → 100.
- Threaded through `Permissions`, `UserData`, `user_preferences.proto`, `NatPreferencesDataSource`, `LoginRepository`(+Impl), `TestLoginRepository`, `DemoLoginRepository`.

### ItemTag Create + Edit
- Validation relaxed: drop alphanumeric and `count >= 2` checks. Valid name is 1–`maximumNameLength` chars (any unicode/symbols/spaces).
- New `description` field: 0–1000 chars, optional, multi-line `OutlinedTextField` (minLines=4). `NatConstants.MAXIMUM_ITEM_TAG_DESCRIPTION_LENGTH = 1_000`.
- Standard keyboard (no `.Ascii`).
- `hasInvalidData` checks both name AND description; Edit's also requires that name OR description changed.

### ItemTag Detail full rewrite
- `HeaderRow`: name + `IdlingTag()` / `CompletedTag()` badge.
- `DescriptionSection`: hidden when blank.
- `CompletedAtRow`: shown only when state == `Completed`.
- `StateToggleButton`: flips between Mark as completed and Mark as idled; uses `MainButtonView`; disabled while `isToggling`.
- ViewModel: new `isToggling`, `completeItemTag()`, `idleItemTag()`. Errors set `uiState.message`; success silently updates `itemTag` (matches the no-success-toast pattern from #31).

### ItemTag list card
- Headline: name + state badge.
- Supporting: description preview (2 lines, ellipsis) + completed timestamp when state == Completed.

### Date helpers
- Add `ZonedDateTime.cardDateTimeString()` and `String.cardDateTimeString()` to `DateUtility`.
- Card date format `MMM dd yyyy` → `yyyy/MM/dd`.
- `ShopDetailCardView` and `ItemTagListCardView` use `cardDateTimeString()`.

### Strings + constants
- New: `name_label`, `description_label`, `completed_at_label`, `item_tag_name_placeholder`, `item_tag_name_is_invalid`, `item_tag_description_is_invalid`, `item_tag_name_help` (format), `item_tag_description_help` (format), `mark_as_completed`, `mark_as_idled`.
- Removed queue-specific: `tag_number`, `tag_number_is_invalid`, `zero_padding`.

### Tests
- `ItemTagCreateViewModelTest`: new validation matrix (unicode/symbols, 100/101 boundary, 1000/1001 description boundary).
- `ItemTagEditViewModelTest`: rewritten — unchanged-form invalid, description-only change valid, blank name invalid, unicode/symbols valid.
- `ItemTagDetailViewModelTest`: + `completeItemTag` / `idleItemTag` success cases.
- `DateUtilityTest`: + `cardDateTimeString` tests.

## Test plan
- [x] `./gradlew clean assembleDebug` passes
- [x] `./gradlew test` passes
- [x] `./gradlew spotlessCheck` passes
- [x] `./gradlew lint` passes
- [x] `./gradlew buildHealth` passes
- [ ] Manual smoke test on emulator: sign in, create tag with `Buy milk 🥛` and multi-line description; mark complete; mark idled; edit description; delete

🤖 Generated with [Claude Code](https://claude.com/claude-code)