### PR TITLE
Reveal swipe actions from trailing (right) edge

### DIFF
--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/common/SwipeableItemWithActions.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/common/SwipeableItemWithActions.kt
@@ -46,7 +46,7 @@ fun SwipeableItemWithActions(
 
   LaunchedEffect(key1 = isRevealed, contextMenuWidth) {
     if (isRevealed) {
-      offset.animateTo(contextMenuWidth)
+      offset.animateTo(-contextMenuWidth)
     } else {
       offset.animateTo(0f)
     }
@@ -59,6 +59,7 @@ fun SwipeableItemWithActions(
   ) {
     Row(
       modifier = Modifier
+        .align(Alignment.CenterEnd)
         .onSizeChanged {
           contextMenuWidth = it.width.toFloat()
         },
@@ -75,15 +76,15 @@ fun SwipeableItemWithActions(
             onHorizontalDrag = { _, dragAmount ->
               scope.launch {
                 val newOffset = (offset.value + dragAmount)
-                  .coerceIn(0f, contextMenuWidth)
+                  .coerceIn(-contextMenuWidth, 0f)
                 offset.snapTo(newOffset)
               }
             },
             onDragEnd = {
               when {
-                offset.value >= contextMenuWidth / 2f -> {
+                offset.value <= -contextMenuWidth / 2f -> {
                   scope.launch {
-                    offset.animateTo(contextMenuWidth)
+                    offset.animateTo(-contextMenuWidth)
                     onExpanded()
                   }
                 }


### PR DESCRIPTION
## Summary
Mirrors NativeAppTemplate-Android PR [#43](https://github.com/nativeapptemplate/NativeAppTemplate-Android/pull/43). Flip `SwipeableItemWithActions` so users drag the row **right-to-left** to reveal action buttons, with the buttons sitting on the **trailing (right)** edge instead of the leading (left) edge. This matches the iOS app's `swipeActions(edge: .trailing)` and the platform-conventional swipe-to-reveal gesture.

### Changes
- Actions `Row` aligned to `Alignment.CenterEnd` of the wrapping `Box`
- Drag offset coerced to `[-contextMenuWidth, 0f]`
- Revealed anchor flipped to `-contextMenuWidth`; half-way fling threshold checks `<= -contextMenuWidth / 2f`

The public API (`isRevealed`, `actions`, `onExpanded`, `onCollapsed`, `content`, `modifier`) is unchanged, so both call sites pick up the new direction with no edits:
- `ShopDetailView` — Complete / Idle actions on item-tag rows
- `ItemTagListView` — Delete action on item-tag rows

## Test plan
- [x] `./gradlew assembleDebug` → BUILD SUCCESSFUL
- [ ] Manual emulator smoke test:
  - **ShopDetailView:** swipe an item-tag row right-to-left → Complete/Idle button appears on the right → tap triggers the action; swipe back or tap content to collapse
  - **ItemTagListView (shop settings):** swipe right-to-left → red Delete icon on the right → tap deletes
  - A left-to-right drag on a collapsed row is a no-op (clamped at `0f`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)