### PR TITLE
Drop unused tags-scanned count and howToUse; tighten ItemTag labels

### DIFF
--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/NatConstants.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/NatConstants.kt
@@ -2,7 +2,6 @@ package com.nativeapptemplate.nativeapptemplatefree
 
 object NatConstants {
   const val SUPPORT_MAIL: String = "support@nativeapptemplate.com"
-  const val HOW_TO_USE_URL: String = "https://myturntag.com/how"
   const val SUPPORT_WEBSITE_URL: String = "https://nativeapptemplate.com"
   const val FAQS_URL: String = "https://nativeapptemplate.com/faqs"
   const val PRIVACY_POLICY_URL: String = "https://nativeapptemplate.com/privacy"

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/app_root/OnboardingView.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/app_root/OnboardingView.kt
@@ -47,7 +47,7 @@ internal fun OnboardingView(
   val fontSizeLarge = 24
   val lineHeightLarge = 26
   val pagerState = rememberPagerState(pageCount = {
-    13
+    8
   })
 
   Scaffold(
@@ -144,10 +144,10 @@ private fun TopAppBar(
     },
     navigationIcon = {
       TextButton(
-        onClick = { context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(NatConstants.HOW_TO_USE_URL))) },
+        onClick = { context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(NatConstants.SUPPORT_WEBSITE_URL))) },
       ) {
         Text(
-          stringResource(R.string.how_to_use),
+          stringResource(R.string.support_website),
         )
       }
     },

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/app_root/OnboardingViewModel.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/app_root/OnboardingViewModel.kt
@@ -18,11 +18,6 @@ class OnboardingViewModel @Inject constructor() : ViewModel() {
         5 -> R.string.onboarding_description6
         6 -> R.string.onboarding_description7
         7 -> R.string.onboarding_description8
-        8 -> R.string.onboarding_description9
-        9 -> R.string.onboarding_description10
-        10 -> R.string.onboarding_description11
-        11 -> R.string.onboarding_description12
-        12 -> R.string.onboarding_description13
         else -> R.string.onboarding_description1
       }
 
@@ -39,11 +34,6 @@ class OnboardingViewModel @Inject constructor() : ViewModel() {
         5 -> R.drawable.ic_overview6
         6 -> R.drawable.ic_overview7
         7 -> R.drawable.ic_overview8
-        8 -> R.drawable.ic_overview9
-        9 -> R.drawable.ic_overview10
-        10 -> R.drawable.ic_overview11
-        11 -> R.drawable.ic_overview12
-        12 -> R.drawable.ic_overview13
         else -> R.drawable.ic_overview1
       }
 

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_detail/ShopDetailView.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_detail/ShopDetailView.kt
@@ -29,11 +29,13 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.nativeapptemplate.nativeapptemplatefree.R
 import com.nativeapptemplate.nativeapptemplatefree.model.ItemTagState.*
 import com.nativeapptemplate.nativeapptemplatefree.ui.common.ActionText
 import com.nativeapptemplate.nativeapptemplatefree.ui.common.ErrorView
@@ -140,6 +142,15 @@ private fun ShopDetailContentView(
       LazyColumn(
         Modifier.padding(24.dp),
       ) {
+        item {
+          Text(
+            text = stringResource(R.string.shop_detail_instruction),
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier
+              .fillMaxWidth()
+              .padding(start = 16.dp, bottom = 8.dp),
+          )
+        }
         itemsIndexed(
           items = itemTags,
         ) { index, itemTag ->

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/item_tag_list/ItemTagCreateView.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/item_tag_list/ItemTagCreateView.kt
@@ -119,7 +119,7 @@ fun ItemTagCreateContentView(
         shape = CircleShape,
 
       ) {
-        Icon(Icons.Filled.Done, contentDescription = stringResource(R.string.label_add_tag))
+        Icon(Icons.Filled.Done, contentDescription = stringResource(R.string.label_add_item_tag))
       }
     },
     modifier = Modifier.fillMaxSize(),
@@ -198,7 +198,7 @@ private fun TopAppBar(
       containerColor = MaterialTheme.colorScheme.primaryContainer,
       titleContentColor = MaterialTheme.colorScheme.primary,
     ),
-    title = { Text(text = stringResource(id = R.string.label_add_tag)) },
+    title = { Text(text = stringResource(id = R.string.label_add_item_tag)) },
     navigationIcon = {
       IconButton(onClick = {
         onBackClick()

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/item_tag_list/ItemTagListView.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/item_tag_list/ItemTagListView.kt
@@ -300,13 +300,13 @@ private fun NoResultsView(
       )
 
       Text(
-        stringResource(R.string.add_tag_description),
+        stringResource(R.string.add_item_tag_description),
         modifier = Modifier
           .padding(horizontal = 16.dp),
       )
 
       MainButtonView(
-        title = stringResource(R.string.label_add_tag),
+        title = stringResource(R.string.label_add_item_tag),
         onClick = { onAddItemTagClick(viewModel.shopId) },
         modifier = Modifier
           .padding(horizontal = 12.dp, vertical = 24.dp),

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shops/ShopListCardView.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shops/ShopListCardView.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Flag
-import androidx.compose.material.icons.outlined.People
 import androidx.compose.material.icons.outlined.Rectangle
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -48,7 +47,6 @@ fun ShopListCardView(
           modifier = Modifier
             .padding(top = 16.dp),
         ) {
-          CountRow(icon = Icons.Outlined.People, count = data.getScannedItemTagsCount(), countLabel = "tags scanned by customers")
           CountRow(icon = Icons.Outlined.Flag, count = data.getCompletedItemTagsCount(), countLabel = "completed tags")
           CountRow(icon = Icons.Outlined.Rectangle, count = data.getItemTagsCount(), countLabel = "all tags")
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,7 +24,6 @@
   <string name="not_connected">⚠️ You aren’t connected to the internet</string>
   <string name="instructions">Instructions</string>
   <string name="open">Open</string>
-  <string name="learn_more">Learn More</string>
   <string name="are_you_sure">Are you sure?</string>
   <string name="full_name">Full Name</string>
   <string name="full_name_is_required">Full name is required.</string>
@@ -67,19 +66,14 @@
   <string name="terms_of_use_updated">Terms of Use Updated</string>
 
   <!-- On-boarding -->
-  <string name="onboarding_description1">Welcome to the app.</string>
-  <string name="onboarding_description2">Welcome to the app.</string>
-  <string name="onboarding_description3">Welcome to the app.</string>
-  <string name="onboarding_description4">Welcome to the app.</string>
-  <string name="onboarding_description5">Welcome to the app.</string>
-  <string name="onboarding_description6">Welcome to the app.</string>
-  <string name="onboarding_description7">Welcome to the app.</string>
-  <string name="onboarding_description8">Welcome to the app.</string>
-  <string name="onboarding_description9">Welcome to the app.</string>
-  <string name="onboarding_description10">Welcome to the app.</string>
-  <string name="onboarding_description11">Welcome to the app.</string>
-  <string name="onboarding_description12">Welcome to the app.</string>
-  <string name="onboarding_description13">Welcome to the app.</string>
+  <string name="onboarding_description1">Welcome to NativeAppTemplate.</string>
+  <string name="onboarding_description2">Sign in to manage your shops and item tags.</string>
+  <string name="onboarding_description3">Organize your work across multiple organizations.</string>
+  <string name="onboarding_description4">Invite teammates to collaborate.</string>
+  <string name="onboarding_description5">Track item tags with a simple idle/completed state.</string>
+  <string name="onboarding_description6">Create, edit, and delete item tags from your shop.</string>
+  <string name="onboarding_description7">Switch between personal and shared organizations.</string>
+  <string name="onboarding_description8">Have fun!</string>
 
   <!-- Shops Screen -->
   <string name="add_shop">Add Shop</string>
@@ -97,6 +91,7 @@
   <string name="message_shop_created">Shop added.</string>
   <string name="message_shop_deleted">Shop removed.</string>
   <string name="message_shop_updated">Shop updated.</string>
+  <string name="shop_detail_instruction">Swipe an item tag to change its status.</string>
   <string name="complete">Complete</string>
   <string name="idle">Idle</string>
 
@@ -112,8 +107,8 @@
   <string name="description_label">Description</string>
   <string name="completed_at_label">Completed at</string>
   <string name="item_tag_name_placeholder">Buy milk</string>
-  <string name="label_add_tag">Add Tag</string>
-  <string name="add_tag_description">Add a new item tag and start changing the tag status.</string>
+  <string name="label_add_item_tag">Add Item Tag</string>
+  <string name="add_item_tag_description">Add a new item tag and start changing the item tag status.</string>
   <string name="item_tag_name_is_invalid">Tag name is invalid.</string>
   <string name="item_tag_description_is_invalid">Tag description is invalid.</string>
   <string name="item_tag_name_help">Name must be 1-%1$d characters.</string>
@@ -121,13 +116,13 @@
   <string name="mark_as_completed">Mark as completed</string>
   <string name="mark_as_idled">Mark as idled</string>
 
-  <string name="message_item_tag_created">Tag created successfully.</string>
-  <string name="message_item_tag_updated">Tag updated successfully.</string>
-  <string name="message_item_tag_deleted">Tag deleted successfully.</string>
+  <string name="message_item_tag_created">Item tag created successfully.</string>
+  <string name="message_item_tag_updated">Item tag updated successfully.</string>
+  <string name="message_item_tag_deleted">Item tag deleted successfully.</string>
 
   <!-- Item Tag Detail Screen -->
-  <string name="label_edit_item_tag">Edit Tag</string>
-  <string name="title_delete_item_tag">Delete Tag</string>
+  <string name="label_edit_item_tag">Edit Item Tag</string>
+  <string name="title_delete_item_tag">Delete Item Tag</string>
 
   <!-- Settings Screen -->
   <string name="mode">Mode</string>
@@ -143,7 +138,6 @@
   <string name="app_section">App</string>
   <string name="version">Version</string>
   <string name="website">Website</string>
-  <string name="how_to_use">How To Use</string>
   <string name="support_website">Support Website</string>
   <string name="faqs">FAQs</string>
   <string name="rate_app">Rate or Review the App</string>

--- a/model/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/model/Attributes.kt
+++ b/model/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/model/Attributes.kt
@@ -68,9 +68,6 @@ data class Attributes(
   @SerialName("item_tags_count")
   val itemTagsCount: Int? = null,
 
-  @SerialName("scanned_item_tags_count")
-  val scannedItemTagsCount: Int? = null,
-
   @SerialName("completed_item_tags_count")
   val completedItemTagsCount: Int? = null,
 

--- a/model/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/model/Data.kt
+++ b/model/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/model/Data.kt
@@ -67,7 +67,5 @@ data class Data(
 
   fun getItemTagsCount(): Int = attributes?.itemTagsCount ?: 0
 
-  fun getScannedItemTagsCount(): Int = attributes?.scannedItemTagsCount ?: 0
-
   fun getCompletedItemTagsCount(): Int = attributes?.completedItemTagsCount ?: 0
 }


### PR DESCRIPTION
## Summary
- Port [NativeAppTemplate-iOS#61](https://github.com/nativeapptemplate/NativeAppTemplate-iOS/pull/61) to Android.
- Drop `scannedItemTagsCount` from `Attributes`/`Data` and remove the "tags scanned by customers" stat from `ShopListCardView`.
- Replace `ShopDetailView`'s missing header with a left-aligned `shop_detail_instruction` ("Swipe an item tag to change its status.").
- Swap `OnboardingView`'s How-To-Use link for the Support Website link; trim onboarding from 13 to 8 descriptions and update placeholder copy to match iOS.
- Normalize ItemTag labels: `label_add_tag`/`add_tag_description` renamed; `label_edit_item_tag`/`title_delete_item_tag` and `message_item_tag_*` values now read "Item Tag" / "Item tag" consistently.
- Drop unused `NatConstants.HOW_TO_USE_URL`, `R.string.how_to_use`, `R.string.learn_more`.

## Test plan
- [x] `./gradlew test` passes
- [x] `./gradlew spotlessCheck lint` passes
- [x] Build & run; verify `ShopDetailView` shows the new instruction text, left-aligned
- [x] Verify Onboarding shows Support Website link in the toolbar and 8 description pages
- [x] Verify `ShopListCardView` no longer shows the scanned tags row
- [x] Verify ItemTag create/edit/delete labels read "Item Tag" everywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)