### PR TITLE
Fix dead password tests and add ItemTag whitespace-name regression tests

### DIFF
--- a/app/src/test/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/app_root/SignInEmailAndPasswordViewModelTest.kt
+++ b/app/src/test/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/app_root/SignInEmailAndPasswordViewModelTest.kt
@@ -97,7 +97,7 @@ class SignInEmailAndPasswordViewModelTest {
 
     viewModel.updatePassword("")
 
-    assertTrue(viewModel.hasInvalidDataEmail())
+    assertTrue(viewModel.hasInvalidDataPassword())
   }
 
   @Test
@@ -106,7 +106,7 @@ class SignInEmailAndPasswordViewModelTest {
 
     viewModel.updatePassword("1234567")
 
-    assertTrue(viewModel.hasInvalidDataEmail())
+    assertTrue(viewModel.hasInvalidDataPassword())
   }
 }
 

--- a/app/src/test/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/app_root/SignUpViewModelTest.kt
+++ b/app/src/test/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/app_root/SignUpViewModelTest.kt
@@ -109,7 +109,7 @@ class SignUpViewModelTest {
 
     viewModel.updatePassword("1234567")
 
-    assertTrue(viewModel.hasInvalidDataEmail())
+    assertTrue(viewModel.hasInvalidDataPassword())
   }
 }
 

--- a/app/src/test/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/item_tag_detail/ItemTagEditViewModelTest.kt
+++ b/app/src/test/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/item_tag_detail/ItemTagEditViewModelTest.kt
@@ -130,6 +130,19 @@ class ItemTagEditViewModelTest {
   }
 
   @Test
+  fun whitespaceOnlyName_isInvalid() = runTest {
+    backgroundScope.launch(UnconfinedTestDispatcher()) { viewModel.uiState.collect() }
+
+    itemTagRepository.sendItemTag(testInputItemTag)
+    viewModel.reload()
+
+    viewModel.updateName("   ")
+
+    assertTrue(viewModel.hasInvalidDataName())
+    assertTrue(viewModel.hasInvalidData())
+  }
+
+  @Test
   fun nameWithSymbolsAndUnicode_isValid() = runTest {
     backgroundScope.launch(UnconfinedTestDispatcher()) { viewModel.uiState.collect() }
 

--- a/app/src/test/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/item_tag_list/ItemTagCreateViewModelTest.kt
+++ b/app/src/test/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/item_tag_list/ItemTagCreateViewModelTest.kt
@@ -82,6 +82,16 @@ class ItemTagCreateViewModelTest {
   }
 
   @Test
+  fun whitespaceOnlyName_isInvalid() = runTest {
+    backgroundScope.launch(UnconfinedTestDispatcher()) { viewModel.uiState.collect() }
+
+    viewModel.updateName("   ")
+
+    assertTrue(viewModel.hasInvalidDataName())
+    assertTrue(viewModel.hasInvalidData())
+  }
+
+  @Test
   fun singleCharacterName_isValid() = runTest {
     backgroundScope.launch(UnconfinedTestDispatcher()) { viewModel.uiState.collect() }
 


### PR DESCRIPTION
## Summary
- Three password tests in `SignInEmailAndPasswordViewModelTest` and `SignUpViewModelTest` called `hasInvalidDataEmail()` instead of `hasInvalidDataPassword()`. Since email is blank by default in those setups, the assertions passed for the wrong reason and the password rules were never actually exercised. Pointed them at `hasInvalidDataPassword()`.
- Added `whitespaceOnlyName_isInvalid` regression tests for both `ItemTagCreateViewModel` and `ItemTagEditViewModel` to lock in the `isBlank()` name validation already in place.

(Ports the test-side fixes from nativeapptemplate/NativeAppTemplate-Android#55. The production `ItemTag*ViewModel.hasInvalidDataName()` methods in this repo already use `isBlank()`, so no production source edits were needed.)

## Test plan
- [x] `./gradlew testDebugUnitTest --tests SignInEmailAndPasswordViewModelTest --tests SignUpViewModelTest --tests ItemTagEditViewModelTest --tests ItemTagCreateViewModelTest` passes
- [x] New `whitespaceOnlyName_isInvalid` tests added for both ItemTag ViewModels

🤖 Generated with [Claude Code](https://claude.com/claude-code)