### PR TITLE
Normalize substrate naming to single NativeAppTemplate stem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - Implemented pagination for item tags list screen.
-- Implemented CodedError system with NATA-XXXX error codes.
+- Implemented CodedError system with NATIVEAPPTEMPLATE-XXXX error codes.
 - Added unit tests for utils, network, and pre-push hook.
 - Added Spotless + ktlint for Kotlin code formatting.
 - Added app version and reorganized settings sections.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ MVVM layered architecture following [Android Modern App Architecture](https://de
 - **Network Layer** (`network/`): `AuthInterceptor` for token injection, `RequestHelper` for request construction.
 - **DI** (`di/modules/`): Hilt modules — `NetModule` (Retrofit/OkHttp), `DataModule` (repository bindings), `DataStoreModule`, `DispatchersModule`, `CoroutineScopesModule`.
 - **DataStore** (`datastore/`): Proto DataStore for user preferences. Proto definitions live in `app/src/main/proto/`.
-- **Navigation**: `NatNavHost.kt` is the top-level nav graph. Three bottom-nav sections: Shops, Scan, Settings. Each section uses nested navigation graphs via `*BaseRoute`.
+- **Navigation**: `NativeAppTemplateNavHost.kt` is the top-level nav graph. Three bottom-nav sections: Shops, Scan, Settings. Each section uses nested navigation graphs via `*BaseRoute`.
 
 ## Key Patterns
 
@@ -49,15 +49,15 @@ MVVM layered architecture following [Android Modern App Architecture](https://de
 - **Proto DataStore**: User preferences and NFC scan state are persisted via Protocol Buffers (lite).
 
 ## Error Handling (CodedError System)
-All errors should use the `CodedError` interface. Error codes use the `NATA-XXXX` prefix (NativeAppTemplate Android).
+All errors should use the `CodedError` interface. Error codes use the `NATIVEAPPTEMPLATE-XXXX` prefix (NativeAppTemplate Android).
 
 | Range | Type | Description |
 |-------|------|-------------|
-| NATA-1xxx | App/general errors | Unexpected errors, catch-all |
-| NATA-2xxx | API/network errors | HTTP request failures, parsing errors |
+| NATIVEAPPTEMPLATE-1xxx | App/general errors | Unexpected errors, catch-all |
+| NATIVEAPPTEMPLATE-2xxx | API/network errors | HTTP request failures, parsing errors |
 
 - New error types must implement `CodedError`
-- Use `codedDescription` (not `message` or `localizedMessage`) in all user-facing error messages — this prepends `[NATA-XXXX]` for `CodedError` types
+- Use `codedDescription` (not `message` or `localizedMessage`) in all user-facing error messages — this prepends `[NATIVEAPPTEMPLATE-XXXX]` for `CodedError` types
 
 ## Testing
 
@@ -76,4 +76,4 @@ cp scripts/pre-push .git/hooks/pre-push
 
 ## Connecting to Local API
 
-The debug `buildConfigField` entries in `app/build.gradle.kts` read `NATEMPLATE_API_DOMAIN`, `NATEMPLATE_API_PORT`, and `NATEMPLATE_API_SCHEME` via `project.findProperty(...)` (not `System.getenv` — Android Studio launched from Finder/Dock does not inherit shell env). Set them in `~/.gradle/gradle.properties` (user-global, per-developer); the same config then works from both the terminal and the IDE. Falls back to `https://api.nativeapptemplate.com` when unset. One-off override: `./gradlew -PNATEMPLATE_API_DOMAIN=... assembleDebug`.
+The debug `buildConfigField` entries in `app/build.gradle.kts` read `NATIVEAPPTEMPLATE_API_DOMAIN`, `NATIVEAPPTEMPLATE_API_PORT`, and `NATIVEAPPTEMPLATE_API_SCHEME` via `project.findProperty(...)` (not `System.getenv` — Android Studio launched from Finder/Dock does not inherit shell env). Set them in `~/.gradle/gradle.properties` (user-global, per-developer); the same config then works from both the terminal and the IDE. Falls back to `https://api.nativeapptemplate.com` when unset. One-off override: `./gradlew -PNATIVEAPPTEMPLATE_API_DOMAIN=... assembleDebug`.

--- a/README.md
+++ b/README.md
@@ -124,12 +124,12 @@ By default the debug build hits the hosted API (`https://api.nativeapptemplate.c
 ```
 # Use your current Wi-Fi IP (macOS: `ipconfig getifaddr en0`), or 10.0.2.2 for emulator → host.
 # Never use 127.0.0.1, localhost, or 0.0.0.0 — Rails and this app must agree on one reachable address.
-NATEMPLATE_API_DOMAIN=192.168.1.21
-NATEMPLATE_API_PORT=3000
-NATEMPLATE_API_SCHEME=http
+NATIVEAPPTEMPLATE_API_DOMAIN=192.168.1.21
+NATIVEAPPTEMPLATE_API_PORT=3000
+NATIVEAPPTEMPLATE_API_SCHEME=http
 ```
 
-Then `./gradlew assembleDebug` — or Build → Rebuild Project from Android Studio. The debug `buildConfigField` entries in `app/build.gradle.kts` read these via `project.findProperty(...)`, so the same config works from both the terminal and the IDE. Remove the three properties to fall back to the hosted default. For a one-off override: `./gradlew -PNATEMPLATE_API_DOMAIN=192.168.1.21 -PNATEMPLATE_API_PORT=3000 -PNATEMPLATE_API_SCHEME=http assembleDebug`.
+Then `./gradlew assembleDebug` — or Build → Rebuild Project from Android Studio. The debug `buildConfigField` entries in `app/build.gradle.kts` read these via `project.findProperty(...)`, so the same config works from both the terminal and the IDE. Remove the three properties to fall back to the hosted default. For a one-off override: `./gradlew -PNATIVEAPPTEMPLATE_API_DOMAIN=192.168.1.21 -PNATIVEAPPTEMPLATE_API_PORT=3000 -PNATIVEAPPTEMPLATE_API_SCHEME=http assembleDebug`.
 
 Cleartext HTTP to private IPs is already permitted in debug via `app/src/debug/res/xml/network_security_config.xml`; the release config (in `app/src/main/`) keeps `api.nativeapptemplate.com` HTTPS-only.
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -26,9 +26,9 @@ android {
     debug {
       extra["alwaysUpdateBuildId"] = false
       isDebuggable = true
-      buildConfigField("String", "DOMAIN", "\"${(project.findProperty("NATEMPLATE_API_DOMAIN") as String?)?.trim() ?: "api.nativeapptemplate.com"}\"")
-      buildConfigField("String", "PORT", "\"${(project.findProperty("NATEMPLATE_API_PORT") as String?)?.trim() ?: ""}\"")
-      buildConfigField("String", "SCHEME", "\"${(project.findProperty("NATEMPLATE_API_SCHEME") as String?)?.trim() ?: "https"}\"")
+      buildConfigField("String", "DOMAIN", "\"${(project.findProperty("NATIVEAPPTEMPLATE_API_DOMAIN") as String?)?.trim() ?: "api.nativeapptemplate.com"}\"")
+      buildConfigField("String", "PORT", "\"${(project.findProperty("NATIVEAPPTEMPLATE_API_PORT") as String?)?.trim() ?: ""}\"")
+      buildConfigField("String", "SCHEME", "\"${(project.findProperty("NATIVEAPPTEMPLATE_API_SCHEME") as String?)?.trim() ?: "https"}\"")
     }
 
     release {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,7 +14,7 @@
           android:icon="@mipmap/ic_launcher"
           android:label="@string/app_name"
           android:supportsRtl="true"
-          android:theme="@style/Theme.Nat.Splash"
+          android:theme="@style/Theme.NativeAppTemplate.Splash"
           android:networkSecurityConfig="@xml/network_security_config"
           tools:ignore="GoogleAppIndexingWarning"
           tools:targetApi="tiramisu">

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/MainActivity.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/MainActivity.kt
@@ -20,10 +20,10 @@ import androidx.lifecycle.repeatOnLifecycle
 import com.nativeapptemplate.nativeapptemplatefree.MainActivityUiState.Loading
 import com.nativeapptemplate.nativeapptemplatefree.MainActivityUiState.Success
 import com.nativeapptemplate.nativeapptemplatefree.data.login.LoginRepository
-import com.nativeapptemplate.nativeapptemplatefree.designsystem.theme.NatTheme
+import com.nativeapptemplate.nativeapptemplatefree.designsystem.theme.NativeAppTemplateTheme
 import com.nativeapptemplate.nativeapptemplatefree.model.DarkThemeConfig
-import com.nativeapptemplate.nativeapptemplatefree.ui.app_root.NatApp
-import com.nativeapptemplate.nativeapptemplatefree.ui.app_root.rememberNatAppState
+import com.nativeapptemplate.nativeapptemplatefree.ui.app_root.NativeAppTemplateApp
+import com.nativeapptemplate.nativeapptemplatefree.ui.app_root.rememberNativeAppTemplateAppState
 import com.nativeapptemplate.nativeapptemplatefree.utils.NetworkMonitor
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
@@ -89,15 +89,15 @@ class MainActivity : ComponentActivity() {
         onDispose {}
       }
 
-      val appState = rememberNatAppState(
+      val appState = rememberNativeAppTemplateAppState(
         loginRepository = loginRepository,
         networkMonitor = networkMonitor,
       )
 
-      NatTheme(
+      NativeAppTemplateTheme(
         darkTheme = darkTheme,
       ) {
-        NatApp(appState)
+        NativeAppTemplateApp(appState)
       }
     }
   }

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/NativeAppTemplateConstants.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/NativeAppTemplateConstants.kt
@@ -1,6 +1,6 @@
 package com.nativeapptemplate.nativeapptemplatefree
 
-object NatConstants {
+object NativeAppTemplateConstants {
   const val SUPPORT_MAIL: String = "support@nativeapptemplate.com"
   const val SUPPORT_WEBSITE_URL: String = "https://nativeapptemplate.com"
   const val FAQS_URL: String = "https://nativeapptemplate.com/faqs"

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/common/errors/ApiException.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/common/errors/ApiException.kt
@@ -7,7 +7,7 @@ sealed class ApiException(message: String, cause: Throwable? = null) :
     val code: Int,
     val apiMessage: String,
   ) : ApiException("$apiMessage [Status: $code]") {
-    override val errorCode: String = "NATA-2001"
+    override val errorCode: String = "NATIVEAPPTEMPLATE-2001"
     override val errorDescription: String = "$apiMessage [Status: $code]"
   }
 
@@ -15,7 +15,7 @@ sealed class ApiException(message: String, cause: Throwable? = null) :
     val rawMessage: String,
     cause: Throwable? = null,
   ) : ApiException("Not processable error($rawMessage).", cause) {
-    override val errorCode: String = "NATA-2002"
+    override val errorCode: String = "NATIVEAPPTEMPLATE-2002"
     override val errorDescription: String = "Processing error: $rawMessage"
   }
 }

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/common/errors/AppError.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/common/errors/AppError.kt
@@ -6,7 +6,7 @@ sealed class AppError(
 ) : Exception(errorDescription), CodedError {
 
   class Unexpected(detail: String? = null) : AppError(
-    errorCode = "NATA-1001",
+    errorCode = "NATIVEAPPTEMPLATE-1001",
     errorDescription = "Unexpected error" + if (detail != null) ": $detail" else "",
   )
 }

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/data/item_tag/ItemTagRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/data/item_tag/ItemTagRepositoryImpl.kt
@@ -1,9 +1,9 @@
 package com.nativeapptemplate.nativeapptemplatefree.data.item_tag
 
-import com.nativeapptemplate.nativeapptemplatefree.datastore.NatPreferencesDataSource
+import com.nativeapptemplate.nativeapptemplatefree.datastore.NativeAppTemplatePreferencesDataSource
 import com.nativeapptemplate.nativeapptemplatefree.model.*
 import com.nativeapptemplate.nativeapptemplatefree.network.Dispatcher
-import com.nativeapptemplate.nativeapptemplatefree.network.NatDispatchers
+import com.nativeapptemplate.nativeapptemplatefree.network.NativeAppTemplateDispatchers
 import com.nativeapptemplate.nativeapptemplatefree.network.emitApiResponse
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.first
@@ -12,9 +12,9 @@ import kotlinx.coroutines.flow.flowOn
 import javax.inject.Inject
 
 class ItemTagRepositoryImpl @Inject constructor(
-  private val mtcPreferencesDataSource: NatPreferencesDataSource,
+  private val mtcPreferencesDataSource: NativeAppTemplatePreferencesDataSource,
   private val api: ItemTagApi,
-  @Dispatcher(NatDispatchers.IO) private val ioDispatcher: CoroutineDispatcher,
+  @Dispatcher(NativeAppTemplateDispatchers.IO) private val ioDispatcher: CoroutineDispatcher,
 ) : ItemTagRepository {
 
   override fun getItemTags(

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/data/login/AccountPasswordRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/data/login/AccountPasswordRepositoryImpl.kt
@@ -1,9 +1,9 @@
 package com.nativeapptemplate.nativeapptemplatefree.data.login
 
-import com.nativeapptemplate.nativeapptemplatefree.datastore.NatPreferencesDataSource
+import com.nativeapptemplate.nativeapptemplatefree.datastore.NativeAppTemplatePreferencesDataSource
 import com.nativeapptemplate.nativeapptemplatefree.model.*
 import com.nativeapptemplate.nativeapptemplatefree.network.Dispatcher
-import com.nativeapptemplate.nativeapptemplatefree.network.NatDispatchers
+import com.nativeapptemplate.nativeapptemplatefree.network.NativeAppTemplateDispatchers
 import com.nativeapptemplate.nativeapptemplatefree.network.emitApiResponse
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.first
@@ -12,9 +12,9 @@ import kotlinx.coroutines.flow.flowOn
 import javax.inject.Inject
 
 class AccountPasswordRepositoryImpl @Inject constructor(
-  private val natPreferencesDataSource: NatPreferencesDataSource,
+  private val natPreferencesDataSource: NativeAppTemplatePreferencesDataSource,
   private val api: AccountPasswordApi,
-  @Dispatcher(NatDispatchers.IO) private val ioDispatcher: CoroutineDispatcher,
+  @Dispatcher(NativeAppTemplateDispatchers.IO) private val ioDispatcher: CoroutineDispatcher,
 ) : AccountPasswordRepository {
   override fun updateAccountPassword(
     updatePasswordBody: UpdatePasswordBody,

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/data/login/LoginRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/data/login/LoginRepositoryImpl.kt
@@ -2,12 +2,12 @@ package com.nativeapptemplate.nativeapptemplatefree.data.login
 
 import androidx.annotation.VisibleForTesting
 import com.nativeapptemplate.nativeapptemplatefree.common.errors.ApiException
-import com.nativeapptemplate.nativeapptemplatefree.datastore.NatPreferencesDataSource
+import com.nativeapptemplate.nativeapptemplatefree.datastore.NativeAppTemplatePreferencesDataSource
 import com.nativeapptemplate.nativeapptemplatefree.model.*
 import com.nativeapptemplate.nativeapptemplatefree.model.LoggedInShopkeeper
 import com.nativeapptemplate.nativeapptemplatefree.model.Login
 import com.nativeapptemplate.nativeapptemplatefree.network.Dispatcher
-import com.nativeapptemplate.nativeapptemplatefree.network.NatDispatchers
+import com.nativeapptemplate.nativeapptemplatefree.network.NativeAppTemplateDispatchers
 import com.nativeapptemplate.nativeapptemplatefree.network.emitApiResponse
 import com.skydoves.sandwich.message
 import com.skydoves.sandwich.suspendOnFailure
@@ -25,8 +25,8 @@ import javax.inject.Inject
 @VisibleForTesting
 class LoginRepositoryImpl @Inject constructor(
   private val api: LoginApi,
-  private val natPreferencesDataSource: NatPreferencesDataSource,
-  @Dispatcher(NatDispatchers.IO) private val ioDispatcher: CoroutineDispatcher,
+  private val natPreferencesDataSource: NativeAppTemplatePreferencesDataSource,
+  @Dispatcher(NativeAppTemplateDispatchers.IO) private val ioDispatcher: CoroutineDispatcher,
 ) : LoginRepository {
 
   override fun login(

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/data/login/SignUpRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/data/login/SignUpRepositoryImpl.kt
@@ -6,7 +6,7 @@ import com.nativeapptemplate.nativeapptemplatefree.model.SignUp
 import com.nativeapptemplate.nativeapptemplatefree.model.SignUpForUpdate
 import com.nativeapptemplate.nativeapptemplatefree.model.Status
 import com.nativeapptemplate.nativeapptemplatefree.network.Dispatcher
-import com.nativeapptemplate.nativeapptemplatefree.network.NatDispatchers
+import com.nativeapptemplate.nativeapptemplatefree.network.NativeAppTemplateDispatchers
 import com.nativeapptemplate.nativeapptemplatefree.network.emitApiResponse
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.flow
@@ -15,7 +15,7 @@ import javax.inject.Inject
 
 class SignUpRepositoryImpl @Inject constructor(
   private val api: SignUpApi,
-  @Dispatcher(NatDispatchers.IO) private val ioDispatcher: CoroutineDispatcher,
+  @Dispatcher(NativeAppTemplateDispatchers.IO) private val ioDispatcher: CoroutineDispatcher,
 ) : SignUpRepository {
   override fun signUp(
     signUp: SignUp,

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/data/shop/ShopRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/data/shop/ShopRepositoryImpl.kt
@@ -1,9 +1,9 @@
 package com.nativeapptemplate.nativeapptemplatefree.data.shop
 
-import com.nativeapptemplate.nativeapptemplatefree.datastore.NatPreferencesDataSource
+import com.nativeapptemplate.nativeapptemplatefree.datastore.NativeAppTemplatePreferencesDataSource
 import com.nativeapptemplate.nativeapptemplatefree.model.*
 import com.nativeapptemplate.nativeapptemplatefree.network.Dispatcher
-import com.nativeapptemplate.nativeapptemplatefree.network.NatDispatchers
+import com.nativeapptemplate.nativeapptemplatefree.network.NativeAppTemplateDispatchers
 import com.nativeapptemplate.nativeapptemplatefree.network.emitApiResponse
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.first
@@ -12,9 +12,9 @@ import kotlinx.coroutines.flow.flowOn
 import javax.inject.Inject
 
 class ShopRepositoryImpl @Inject constructor(
-  private val natPreferencesDataSource: NatPreferencesDataSource,
+  private val natPreferencesDataSource: NativeAppTemplatePreferencesDataSource,
   private val api: ShopApi,
-  @Dispatcher(NatDispatchers.IO) private val ioDispatcher: CoroutineDispatcher,
+  @Dispatcher(NativeAppTemplateDispatchers.IO) private val ioDispatcher: CoroutineDispatcher,
 ) : ShopRepository {
 
   override fun getShops() = flow {

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/datastore/NativeAppTemplatePreferencesDataSource.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/datastore/NativeAppTemplatePreferencesDataSource.kt
@@ -15,7 +15,7 @@ import kotlinx.coroutines.flow.map
 import java.io.IOException
 import javax.inject.Inject
 
-class NatPreferencesDataSource @Inject constructor(
+class NativeAppTemplatePreferencesDataSource @Inject constructor(
   private val userPreferences: DataStore<UserPreferences>,
 ) {
   val userData = userPreferences.data
@@ -77,7 +77,7 @@ class NatPreferencesDataSource @Inject constructor(
         }
       }
     } catch (ioException: IOException) {
-      Log.e("NatPreferences", "Failed to update user preferences", ioException)
+      Log.e("NativeAppTemplatePreferences", "Failed to update user preferences", ioException)
       throw ioException
     }
   }
@@ -93,7 +93,7 @@ class NatPreferencesDataSource @Inject constructor(
         }
       }
     } catch (ioException: IOException) {
-      Log.e("NatPreferences", "Failed to update user preferences", ioException)
+      Log.e("NativeAppTemplatePreferences", "Failed to update user preferences", ioException)
       throw ioException
     }
   }
@@ -112,7 +112,7 @@ class NatPreferencesDataSource @Inject constructor(
         }
       }
     } catch (ioException: IOException) {
-      Log.e("NatPreferences", "Failed to update user preferences", ioException)
+      Log.e("NativeAppTemplatePreferences", "Failed to update user preferences", ioException)
       throw ioException
     }
   }
@@ -125,7 +125,7 @@ class NatPreferencesDataSource @Inject constructor(
         }
       }
     } catch (ioException: IOException) {
-      Log.e("NatPreferences", "Failed to update user preferences", ioException)
+      Log.e("NativeAppTemplatePreferences", "Failed to update user preferences", ioException)
       throw ioException
     }
   }
@@ -143,7 +143,7 @@ class NatPreferencesDataSource @Inject constructor(
         }
       }
     } catch (ioException: IOException) {
-      Log.e("NatPreferences", "Failed to update user preferences", ioException)
+      Log.e("NativeAppTemplatePreferences", "Failed to update user preferences", ioException)
       throw ioException
     }
   }
@@ -154,7 +154,7 @@ class NatPreferencesDataSource @Inject constructor(
         it.copy { this.didShowTapShopBelowTip = didShowTapShopBelowTip }
       }
     } catch (ioException: IOException) {
-      Log.e("NatPreferences", "Failed to update user preferences", ioException)
+      Log.e("NativeAppTemplatePreferences", "Failed to update user preferences", ioException)
       throw ioException
     }
   }
@@ -165,7 +165,7 @@ class NatPreferencesDataSource @Inject constructor(
         it.copy { this.isEmailUpdated = isEmailUpdated }
       }
     } catch (ioException: IOException) {
-      Log.e("NatPreferences", "Failed to update user preferences", ioException)
+      Log.e("NativeAppTemplatePreferences", "Failed to update user preferences", ioException)
       throw ioException
     }
   }
@@ -176,7 +176,7 @@ class NatPreferencesDataSource @Inject constructor(
         it.copy { this.isMyAccountDeleted = isMyAccountDeleted }
       }
     } catch (ioException: IOException) {
-      Log.e("NatPreferences", "Failed to update user preferences", ioException)
+      Log.e("NativeAppTemplatePreferences", "Failed to update user preferences", ioException)
       throw ioException
     }
   }
@@ -187,7 +187,7 @@ class NatPreferencesDataSource @Inject constructor(
         it.copy { this.isShopDeleted = isShopDeleted }
       }
     } catch (ioException: IOException) {
-      Log.e("NatPreferences", "Failed to update user preferences", ioException)
+      Log.e("NativeAppTemplatePreferences", "Failed to update user preferences", ioException)
       throw ioException
     }
   }
@@ -198,7 +198,7 @@ class NatPreferencesDataSource @Inject constructor(
         it.toBuilder().clear().build()
       }
     } catch (ioException: IOException) {
-      Log.e("NatPreferences", "Failed to clear user preferences", ioException)
+      Log.e("NativeAppTemplatePreferences", "Failed to clear user preferences", ioException)
       throw ioException
     }
   }

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/designsystem/component/Background.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/designsystem/component/Background.kt
@@ -21,7 +21,7 @@ import com.nativeapptemplate.nativeapptemplatefree.designsystem.theme.LocalBackg
  * @param content The background content.
  */
 @Composable
-fun NatBackground(
+fun NativeAppTemplateBackground(
   modifier: Modifier = Modifier,
   content: @Composable () -> Unit,
 ) {

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/designsystem/component/Navigation.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/designsystem/component/Navigation.kt
@@ -31,7 +31,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.nativeapptemplate.nativeapptemplatefree.designsystem.theme.NatTheme
+import com.nativeapptemplate.nativeapptemplatefree.designsystem.theme.NativeAppTemplateTheme
 
 /**
  * Now in Android navigation bar item with icon and label content slots. Wraps Material 3
@@ -49,7 +49,7 @@ import com.nativeapptemplate.nativeapptemplatefree.designsystem.theme.NatTheme
  * only be shown when this item is selected.
  */
 @Composable
-fun RowScope.NatNavigationBarItem(
+fun RowScope.NativeAppTemplateNavigationBarItem(
   selected: Boolean,
   onClick: () -> Unit,
   modifier: Modifier = Modifier,
@@ -68,11 +68,11 @@ fun RowScope.NatNavigationBarItem(
     label = label,
     alwaysShowLabel = alwaysShowLabel,
     colors = NavigationBarItemDefaults.colors(
-      selectedIconColor = NatNavigationDefaults.navigationSelectedItemColor(),
-      unselectedIconColor = NatNavigationDefaults.navigationContentColor(),
-      selectedTextColor = NatNavigationDefaults.navigationSelectedItemColor(),
-      unselectedTextColor = NatNavigationDefaults.navigationContentColor(),
-      indicatorColor = NatNavigationDefaults.navigationIndicatorColor(),
+      selectedIconColor = NativeAppTemplateNavigationDefaults.navigationSelectedItemColor(),
+      unselectedIconColor = NativeAppTemplateNavigationDefaults.navigationContentColor(),
+      selectedTextColor = NativeAppTemplateNavigationDefaults.navigationSelectedItemColor(),
+      unselectedTextColor = NativeAppTemplateNavigationDefaults.navigationContentColor(),
+      indicatorColor = NativeAppTemplateNavigationDefaults.navigationIndicatorColor(),
     ),
   )
 }
@@ -85,13 +85,13 @@ fun RowScope.NatNavigationBarItem(
  * [NavigationBarItem]s.
  */
 @Composable
-fun NatNavigationBar(
+fun NativeAppTemplateNavigationBar(
   modifier: Modifier = Modifier,
   content: @Composable RowScope.() -> Unit,
 ) {
   NavigationBar(
     modifier = modifier,
-    contentColor = NatNavigationDefaults.navigationContentColor(),
+    contentColor = NativeAppTemplateNavigationDefaults.navigationContentColor(),
     tonalElevation = 0.dp,
     content = content,
   )
@@ -99,7 +99,7 @@ fun NatNavigationBar(
 
 @ThemePreviews
 @Composable
-fun NatNavigationBarPreview() {
+fun NativeAppTemplateNavigationBarPreview() {
   val items = listOf("Shops", "Settings")
   val icons = listOf(
     Icons.Outlined.Storefront,
@@ -110,10 +110,10 @@ fun NatNavigationBarPreview() {
     Icons.Rounded.Settings,
   )
 
-  NatTheme {
-    NatNavigationBar {
+  NativeAppTemplateTheme {
+    NativeAppTemplateNavigationBar {
       items.forEachIndexed { index, item ->
-        NatNavigationBarItem(
+        NativeAppTemplateNavigationBarItem(
           icon = {
             Icon(
               imageVector = icons[index],
@@ -138,7 +138,7 @@ fun NatNavigationBarPreview() {
 /**
  * Now in Android navigation default values.
  */
-object NatNavigationDefaults {
+object NativeAppTemplateNavigationDefaults {
   @Composable
   fun navigationContentColor() = MaterialTheme.colorScheme.onSurfaceVariant
 

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/designsystem/theme/Theme.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/designsystem/theme/Theme.kt
@@ -66,7 +66,7 @@ val DarkDefaultColorScheme = darkColorScheme(
 )
 
 @Composable
-fun NatTheme(
+fun NativeAppTemplateTheme(
   darkTheme: Boolean = isSystemInDarkTheme(),
   content: @Composable () -> Unit,
 ) {
@@ -91,7 +91,7 @@ fun NatTheme(
   ) {
     MaterialTheme(
       colorScheme = colorScheme,
-      typography = NatTypography,
+      typography = NativeAppTemplateTypography,
       content = content,
     )
   }

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/designsystem/theme/Type.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/designsystem/theme/Type.kt
@@ -8,7 +8,7 @@ import androidx.compose.ui.text.style.LineHeightStyle.Alignment
 import androidx.compose.ui.text.style.LineHeightStyle.Trim
 import androidx.compose.ui.unit.sp
 
-internal val NatTypography = Typography(
+internal val NativeAppTemplateTypography = Typography(
   displayLarge = TextStyle(
     fontWeight = FontWeight.Normal,
     fontSize = 57.sp,

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/di/modules/CoroutineScopesModule.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/di/modules/CoroutineScopesModule.kt
@@ -17,7 +17,7 @@
 package com.nativeapptemplate.nativeapptemplatefree.di.modules
 
 import com.nativeapptemplate.nativeapptemplatefree.network.Dispatcher
-import com.nativeapptemplate.nativeapptemplatefree.network.NatDispatchers
+import com.nativeapptemplate.nativeapptemplatefree.network.NativeAppTemplateDispatchers
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -39,6 +39,6 @@ internal object CoroutineScopesModule {
   @Singleton
   @ApplicationScope
   fun providesCoroutineScope(
-    @Dispatcher(NatDispatchers.Default) dispatcher: CoroutineDispatcher,
+    @Dispatcher(NativeAppTemplateDispatchers.Default) dispatcher: CoroutineDispatcher,
   ): CoroutineScope = CoroutineScope(SupervisorJob() + dispatcher)
 }

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/di/modules/DataStoreModule.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/di/modules/DataStoreModule.kt
@@ -23,7 +23,7 @@ import androidx.datastore.dataStoreFile
 import com.nativeapptemplate.nativeapptemplatefree.UserPreferences
 import com.nativeapptemplate.nativeapptemplatefree.datastore.UserPreferencesSerializer
 import com.nativeapptemplate.nativeapptemplatefree.network.Dispatcher
-import com.nativeapptemplate.nativeapptemplatefree.network.NatDispatchers.IO
+import com.nativeapptemplate.nativeapptemplatefree.network.NativeAppTemplateDispatchers.IO
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/di/modules/DispatchersModule.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/di/modules/DispatchersModule.kt
@@ -1,7 +1,7 @@
 package com.nativeapptemplate.nativeapptemplatefree.di.modules
 
 import com.nativeapptemplate.nativeapptemplatefree.network.Dispatcher
-import com.nativeapptemplate.nativeapptemplatefree.network.NatDispatchers
+import com.nativeapptemplate.nativeapptemplatefree.network.NativeAppTemplateDispatchers
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -13,10 +13,10 @@ import kotlinx.coroutines.Dispatchers
 @InstallIn(SingletonComponent::class)
 object DispatchersModule {
   @Provides
-  @Dispatcher(NatDispatchers.IO)
+  @Dispatcher(NativeAppTemplateDispatchers.IO)
   fun providesIODispatcher(): CoroutineDispatcher = Dispatchers.IO
 
   @Provides
-  @Dispatcher(NatDispatchers.Default)
+  @Dispatcher(NativeAppTemplateDispatchers.Default)
   fun providesDefaultDispatcher(): CoroutineDispatcher = Dispatchers.Default
 }

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/di/modules/NetModule.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/di/modules/NetModule.kt
@@ -3,7 +3,7 @@ package com.nativeapptemplate.nativeapptemplatefree.di.modules
 import androidx.tracing.trace
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import com.nativeapptemplate.nativeapptemplatefree.BuildConfig
-import com.nativeapptemplate.nativeapptemplatefree.NatConstants
+import com.nativeapptemplate.nativeapptemplatefree.NativeAppTemplateConstants
 import com.nativeapptemplate.nativeapptemplatefree.data.item_tag.ItemTagApi
 import com.nativeapptemplate.nativeapptemplatefree.data.login.AccountPasswordApi
 import com.nativeapptemplate.nativeapptemplatefree.data.login.LoginApi
@@ -84,7 +84,7 @@ class NetModule {
   @Provides
   fun provideRetrofit(okHttpClient: OkHttpClient): Retrofit {
     return Retrofit.Builder()
-      .baseUrl(NatConstants.baseUrlString())
+      .baseUrl(NativeAppTemplateConstants.baseUrlString())
       .client(okHttpClient)
       .addConverterFactory(converter)
       .addCallAdapterFactory(ApiResponseCallAdapterFactory.create())
@@ -108,7 +108,7 @@ class NetModule {
 
   @Provides
   @Singleton
-  fun okHttpCallFactory(): Call.Factory = trace("NatOkHttpClient") {
+  fun okHttpCallFactory(): Call.Factory = trace("NativeAppTemplateOkHttpClient") {
     OkHttpClient.Builder()
       .addInterceptor(
         HttpLoggingInterceptor()

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/navigation/NativeAppTemplateNavHost.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/navigation/NativeAppTemplateNavHost.kt
@@ -7,7 +7,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.compose.NavHost
-import com.nativeapptemplate.nativeapptemplatefree.ui.app_root.NatAppState
+import com.nativeapptemplate.nativeapptemplatefree.ui.app_root.NativeAppTemplateAppState
 import com.nativeapptemplate.nativeapptemplatefree.ui.app_root.navigation.acceptPrivacyView
 import com.nativeapptemplate.nativeapptemplatefree.ui.app_root.navigation.acceptTermsView
 import com.nativeapptemplate.nativeapptemplatefree.ui.app_root.navigation.forgotPasswordView
@@ -61,8 +61,8 @@ import com.nativeapptemplate.nativeapptemplatefree.ui.shops.navigation.shopListV
  * within each route is handled using state and Back Handlers.
  */
 @Composable
-fun NatNavHost(
-  appState: NatAppState,
+fun NativeAppTemplateNavHost(
+  appState: NativeAppTemplateAppState,
   onShowSnackbar: suspend (String, String?, SnackbarDuration?) -> Boolean,
   modifier: Modifier = Modifier,
 ) {

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/network/AuthInterceptor.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/network/AuthInterceptor.kt
@@ -1,6 +1,6 @@
 package com.nativeapptemplate.nativeapptemplatefree.network
 
-import com.nativeapptemplate.nativeapptemplatefree.datastore.NatPreferencesDataSource
+import com.nativeapptemplate.nativeapptemplatefree.datastore.NativeAppTemplatePreferencesDataSource
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import okhttp3.Interceptor
@@ -12,7 +12,7 @@ import kotlin.coroutines.cancellation.CancellationException
 
 @Singleton
 class AuthInterceptor @Inject constructor(
-  private val natPreferencesDataSource: NatPreferencesDataSource,
+  private val natPreferencesDataSource: NativeAppTemplatePreferencesDataSource,
 ) : Interceptor {
   private suspend fun requestHelper(): RequestHelper {
     val userData = natPreferencesDataSource.userData.first()

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/network/NativeAppTemplateDispatchers.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/network/NativeAppTemplateDispatchers.kt
@@ -21,9 +21,9 @@ import kotlin.annotation.AnnotationRetention.RUNTIME
 
 @Qualifier
 @Retention(RUNTIME)
-annotation class Dispatcher(val natDispatcher: NatDispatchers)
+annotation class Dispatcher(val natDispatcher: NativeAppTemplateDispatchers)
 
-enum class NatDispatchers {
+enum class NativeAppTemplateDispatchers {
   Default,
   IO,
 }

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/app_root/AcceptPrivacyView.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/app_root/AcceptPrivacyView.kt
@@ -31,11 +31,11 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.nativeapptemplate.nativeapptemplatefree.NatConstants
+import com.nativeapptemplate.nativeapptemplatefree.NativeAppTemplateConstants
 import com.nativeapptemplate.nativeapptemplatefree.R
 import com.nativeapptemplate.nativeapptemplatefree.ui.common.LoadingView
 import com.nativeapptemplate.nativeapptemplatefree.ui.common.MainButtonView
-import com.nativeapptemplate.nativeapptemplatefree.ui.common.NatAlertDialog
+import com.nativeapptemplate.nativeapptemplatefree.ui.common.NativeAppTemplateAlertDialog
 import com.nativeapptemplate.nativeapptemplatefree.ui.common.SnackbarMessageEffect
 import com.nativeapptemplate.nativeapptemplatefree.utils.Utility.restartApp
 
@@ -54,7 +54,7 @@ fun AcceptPrivacyView(
 
   if (uiState.isUpdated) {
     val context = LocalContext.current
-    NatAlertDialog(
+    NativeAppTemplateAlertDialog(
       dialogTitle = stringResource(R.string.confirmed_privacy_version_updated),
       onDismissRequest = { context.restartApp() },
     )
@@ -111,7 +111,7 @@ fun AcceptPrivacyContentView(
 
         withLink(
           LinkAnnotation.Url(
-            NatConstants.PRIVACY_POLICY_URL,
+            NativeAppTemplateConstants.PRIVACY_POLICY_URL,
             TextLinkStyles(style = SpanStyle(color = MaterialTheme.colorScheme.primary)),
           ),
         ) {

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/app_root/AcceptTermsView.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/app_root/AcceptTermsView.kt
@@ -31,11 +31,11 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.nativeapptemplate.nativeapptemplatefree.NatConstants
+import com.nativeapptemplate.nativeapptemplatefree.NativeAppTemplateConstants
 import com.nativeapptemplate.nativeapptemplatefree.R
 import com.nativeapptemplate.nativeapptemplatefree.ui.common.LoadingView
 import com.nativeapptemplate.nativeapptemplatefree.ui.common.MainButtonView
-import com.nativeapptemplate.nativeapptemplatefree.ui.common.NatAlertDialog
+import com.nativeapptemplate.nativeapptemplatefree.ui.common.NativeAppTemplateAlertDialog
 import com.nativeapptemplate.nativeapptemplatefree.ui.common.SnackbarMessageEffect
 import com.nativeapptemplate.nativeapptemplatefree.utils.Utility.restartApp
 
@@ -54,7 +54,7 @@ fun AcceptTermsView(
 
   if (uiState.isUpdated) {
     val context = LocalContext.current
-    NatAlertDialog(
+    NativeAppTemplateAlertDialog(
       dialogTitle = stringResource(R.string.confirmed_terms_version_updated),
       onDismissRequest = { context.restartApp() },
     )
@@ -111,7 +111,7 @@ fun AcceptTermsContentView(
 
         withLink(
           LinkAnnotation.Url(
-            NatConstants.TERMS_OF_USE_URL,
+            NativeAppTemplateConstants.TERMS_OF_USE_URL,
             TextLinkStyles(style = SpanStyle(color = MaterialTheme.colorScheme.primary)),
           ),
         ) {

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/app_root/ForgotPasswordView.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/app_root/ForgotPasswordView.kt
@@ -36,10 +36,10 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.nativeapptemplate.nativeapptemplatefree.NatConstants
+import com.nativeapptemplate.nativeapptemplatefree.NativeAppTemplateConstants
 import com.nativeapptemplate.nativeapptemplatefree.R
 import com.nativeapptemplate.nativeapptemplatefree.ui.common.LoadingView
-import com.nativeapptemplate.nativeapptemplatefree.ui.common.NatAlertDialog
+import com.nativeapptemplate.nativeapptemplatefree.ui.common.NativeAppTemplateAlertDialog
 import com.nativeapptemplate.nativeapptemplatefree.ui.common.SnackbarMessageEffect
 
 @Composable
@@ -57,7 +57,7 @@ fun ForgotPasswordView(
   )
 
   if (uiState.isSent) {
-    NatAlertDialog(
+    NativeAppTemplateAlertDialog(
       dialogTitle = stringResource(R.string.sent_reset_password_instruction),
       onDismissRequest = { onBackClick() },
     )
@@ -135,7 +135,7 @@ fun ForgotPasswordContentView(
             text = stringResource(R.string.email),
           )
         },
-        placeholder = { Text(NatConstants.PLACEHOLDER_EMAIL) },
+        placeholder = { Text(NativeAppTemplateConstants.PLACEHOLDER_EMAIL) },
         value = uiState.email,
         onValueChange = { viewModel.updateEmail(it) },
         supportingText = {

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/app_root/ForgotPasswordViewModel.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/app_root/ForgotPasswordViewModel.kt
@@ -2,7 +2,7 @@ package com.nativeapptemplate.nativeapptemplatefree.ui.app_root
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.nativeapptemplate.nativeapptemplatefree.NatConstants
+import com.nativeapptemplate.nativeapptemplatefree.NativeAppTemplateConstants
 import com.nativeapptemplate.nativeapptemplatefree.common.errors.codedDescription
 import com.nativeapptemplate.nativeapptemplatefree.data.login.SignUpRepository
 import com.nativeapptemplate.nativeapptemplatefree.model.SendResetPassword
@@ -43,7 +43,7 @@ class ForgotPasswordViewModel @Inject constructor(
     viewModelScope.launch {
       val sendResetPassword = SendResetPassword(
         email = uiState.value.email.trim(),
-        redirectUrl = SendResetPassword.redirectUrlString(NatConstants.baseUrlString()),
+        redirectUrl = SendResetPassword.redirectUrlString(NativeAppTemplateConstants.baseUrlString()),
       )
 
       val booleanFlow = signUpRepository.sendResetPasswordInstruction(sendResetPassword)

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/app_root/NativeAppTemplateApp.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/app_root/NativeAppTemplateApp.kt
@@ -35,10 +35,10 @@ import androidx.navigation.NavDestination
 import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.NavDestination.Companion.hierarchy
 import com.nativeapptemplate.nativeapptemplatefree.R
-import com.nativeapptemplate.nativeapptemplatefree.designsystem.component.NatBackground
-import com.nativeapptemplate.nativeapptemplatefree.designsystem.component.NatNavigationBar
-import com.nativeapptemplate.nativeapptemplatefree.designsystem.component.NatNavigationBarItem
-import com.nativeapptemplate.nativeapptemplatefree.navigation.NatNavHost
+import com.nativeapptemplate.nativeapptemplatefree.designsystem.component.NativeAppTemplateBackground
+import com.nativeapptemplate.nativeapptemplatefree.designsystem.component.NativeAppTemplateNavigationBar
+import com.nativeapptemplate.nativeapptemplatefree.designsystem.component.NativeAppTemplateNavigationBarItem
+import com.nativeapptemplate.nativeapptemplatefree.navigation.NativeAppTemplateNavHost
 import com.nativeapptemplate.nativeapptemplatefree.navigation.TopLevelDestination
 import kotlin.reflect.KClass
 
@@ -46,8 +46,8 @@ import kotlin.reflect.KClass
   ExperimentalComposeUiApi::class,
 )
 @Composable
-fun NatApp(appState: NatAppState) {
-  NatBackground {
+fun NativeAppTemplateApp(appState: NativeAppTemplateAppState) {
+  NativeAppTemplateBackground {
     val snackbarHostState = remember { SnackbarHostState() }
 
     val isOffline by appState.isOffline.collectAsStateWithLifecycle()
@@ -116,11 +116,11 @@ fun NatApp(appState: NatAppState) {
       bottomBar = {
         val shouldShowBottomBar by appState.shouldShowBottomBar.collectAsStateWithLifecycle()
         if (shouldShowBottomBar) {
-          NatBottomBar(
+          NativeAppTemplateBottomBar(
             destinations = appState.topLevelDestinations,
             onNavigateToDestination = appState::navigateToTopLevelDestination,
             currentDestination = appState.currentDestination,
-            modifier = Modifier.testTag("NatBottomBar"),
+            modifier = Modifier.testTag("NativeAppTemplateBottomBar"),
           )
         }
       },
@@ -137,7 +137,7 @@ fun NatApp(appState: NatAppState) {
           ),
       ) {
         Column(Modifier.fillMaxSize()) {
-          NatNavHost(
+          NativeAppTemplateNavHost(
             appState = appState,
             onShowSnackbar = { message, action, duration ->
               snackbarHostState.showSnackbar(
@@ -154,19 +154,19 @@ fun NatApp(appState: NatAppState) {
 }
 
 @Composable
-private fun NatBottomBar(
+private fun NativeAppTemplateBottomBar(
   destinations: List<TopLevelDestination>,
   onNavigateToDestination: (TopLevelDestination) -> Unit,
   currentDestination: NavDestination?,
   modifier: Modifier = Modifier,
 ) {
-  NatNavigationBar(
+  NativeAppTemplateNavigationBar(
     modifier = modifier,
   ) {
     destinations.forEach { destination ->
       val selected = currentDestination.isRouteInHierarchy(destination.baseRoute)
 
-      NatNavigationBarItem(
+      NativeAppTemplateNavigationBarItem(
         selected = selected,
         onClick = { onNavigateToDestination(destination) },
         icon = {

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/app_root/NativeAppTemplateAppState.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/app_root/NativeAppTemplateAppState.kt
@@ -26,12 +26,12 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 
 @Composable
-fun rememberNatAppState(
+fun rememberNativeAppTemplateAppState(
   loginRepository: LoginRepository,
   networkMonitor: NetworkMonitor,
   coroutineScope: CoroutineScope = rememberCoroutineScope(),
   navController: NavHostController = rememberNavController(),
-): NatAppState {
+): NativeAppTemplateAppState {
 //  NavigationTrackingSideEffect(navController)
   return remember(
     loginRepository,
@@ -39,7 +39,7 @@ fun rememberNatAppState(
     coroutineScope,
     networkMonitor,
   ) {
-    NatAppState(
+    NativeAppTemplateAppState(
       loginRepository = loginRepository,
       navController = navController,
       coroutineScope = coroutineScope,
@@ -49,7 +49,7 @@ fun rememberNatAppState(
 }
 
 @Stable
-class NatAppState(
+class NativeAppTemplateAppState(
   val loginRepository: LoginRepository,
   val navController: NavHostController,
   val coroutineScope: CoroutineScope,

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/app_root/NeedAppUpdatesView.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/app_root/NeedAppUpdatesView.kt
@@ -27,7 +27,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.nativeapptemplate.nativeapptemplatefree.R
-import com.nativeapptemplate.nativeapptemplatefree.designsystem.theme.NatTheme
+import com.nativeapptemplate.nativeapptemplatefree.designsystem.theme.NativeAppTemplateTheme
 import com.nativeapptemplate.nativeapptemplatefree.utils.Utility
 
 @Composable
@@ -93,7 +93,7 @@ fun NeedAppUpdatesView() {
 @Preview
 @Composable
 private fun LoadingStatePreview() {
-  NatTheme {
+  NativeAppTemplateTheme {
     NeedAppUpdatesView()
   }
 }

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/app_root/OnboardingView.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/app_root/OnboardingView.kt
@@ -36,7 +36,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.nativeapptemplate.nativeapptemplatefree.NatConstants
+import com.nativeapptemplate.nativeapptemplatefree.NativeAppTemplateConstants
 import com.nativeapptemplate.nativeapptemplatefree.R
 import com.nativeapptemplate.nativeapptemplatefree.ui.common.NonScaledSp.nonScaledSp
 
@@ -148,7 +148,7 @@ private fun TopAppBar(
     },
     navigationIcon = {
       TextButton(
-        onClick = { context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(NatConstants.SUPPORT_WEBSITE_URL))) },
+        onClick = { context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(NativeAppTemplateConstants.SUPPORT_WEBSITE_URL))) },
       ) {
         Text(
           stringResource(R.string.support_website),

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/app_root/ResendConfirmationInstructionsView.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/app_root/ResendConfirmationInstructionsView.kt
@@ -36,10 +36,10 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.nativeapptemplate.nativeapptemplatefree.NatConstants
+import com.nativeapptemplate.nativeapptemplatefree.NativeAppTemplateConstants
 import com.nativeapptemplate.nativeapptemplatefree.R
 import com.nativeapptemplate.nativeapptemplatefree.ui.common.LoadingView
-import com.nativeapptemplate.nativeapptemplatefree.ui.common.NatAlertDialog
+import com.nativeapptemplate.nativeapptemplatefree.ui.common.NativeAppTemplateAlertDialog
 import com.nativeapptemplate.nativeapptemplatefree.ui.common.SnackbarMessageEffect
 
 @Composable
@@ -57,7 +57,7 @@ fun ResendConfirmationInstructionsView(
   )
 
   if (uiState.isSent) {
-    NatAlertDialog(
+    NativeAppTemplateAlertDialog(
       dialogTitle = stringResource(R.string.sent_confirmation_instruction),
       onDismissRequest = { onBackClick() },
     )
@@ -135,7 +135,7 @@ fun ResendConfirmationInstructionsContentView(
             text = stringResource(R.string.email),
           )
         },
-        placeholder = { Text(NatConstants.PLACEHOLDER_EMAIL) },
+        placeholder = { Text(NativeAppTemplateConstants.PLACEHOLDER_EMAIL) },
         value = uiState.email,
         onValueChange = { viewModel.updateEmail(it) },
         supportingText = {

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/app_root/ResendConfirmationInstructionsViewModel.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/app_root/ResendConfirmationInstructionsViewModel.kt
@@ -2,7 +2,7 @@ package com.nativeapptemplate.nativeapptemplatefree.ui.app_root
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.nativeapptemplate.nativeapptemplatefree.NatConstants
+import com.nativeapptemplate.nativeapptemplatefree.NativeAppTemplateConstants
 import com.nativeapptemplate.nativeapptemplatefree.common.errors.codedDescription
 import com.nativeapptemplate.nativeapptemplatefree.data.login.SignUpRepository
 import com.nativeapptemplate.nativeapptemplatefree.model.SendConfirmation
@@ -43,7 +43,7 @@ class ResendConfirmationInstructionsViewModel @Inject constructor(
     viewModelScope.launch {
       val sendConfirmation = SendConfirmation(
         email = uiState.value.email.trim(),
-        redirectUrl = SendConfirmation.redirectUrlString(NatConstants.baseUrlString()),
+        redirectUrl = SendConfirmation.redirectUrlString(NativeAppTemplateConstants.baseUrlString()),
       )
 
       val booleanFlow = signUpRepository.sendConfirmationInstruction(sendConfirmation)

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/app_root/SignInEmailAndPasswordView.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/app_root/SignInEmailAndPasswordView.kt
@@ -39,7 +39,7 @@ import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.nativeapptemplate.nativeapptemplatefree.NatConstants
+import com.nativeapptemplate.nativeapptemplatefree.NativeAppTemplateConstants
 import com.nativeapptemplate.nativeapptemplatefree.R
 import com.nativeapptemplate.nativeapptemplatefree.ui.common.LoadingView
 import com.nativeapptemplate.nativeapptemplatefree.ui.common.MainButtonView
@@ -145,7 +145,7 @@ fun SignInEmailAndPasswordContentView(
             text = stringResource(R.string.email),
           )
         },
-        placeholder = { Text(NatConstants.PLACEHOLDER_EMAIL) },
+        placeholder = { Text(NativeAppTemplateConstants.PLACEHOLDER_EMAIL) },
         value = uiState.email,
         onValueChange = { viewModel.updateEmail(it) },
         supportingText = {
@@ -174,7 +174,7 @@ fun SignInEmailAndPasswordContentView(
             text = stringResource(R.string.label_password),
           )
         },
-        placeholder = { Text(NatConstants.PLACEHOLDER_PASSWORD) },
+        placeholder = { Text(NativeAppTemplateConstants.PLACEHOLDER_PASSWORD) },
         value = uiState.password,
         onValueChange = { viewModel.updatePassword(it) },
         supportingText = {

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/app_root/SignInEmailAndPasswordViewModel.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/app_root/SignInEmailAndPasswordViewModel.kt
@@ -3,7 +3,7 @@ package com.nativeapptemplate.nativeapptemplatefree.ui.app_root
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.nativeapptemplate.nativeapptemplatefree.NatConstants
+import com.nativeapptemplate.nativeapptemplatefree.NativeAppTemplateConstants
 import com.nativeapptemplate.nativeapptemplatefree.common.errors.codedDescription
 import com.nativeapptemplate.nativeapptemplatefree.data.login.LoginRepository
 import com.nativeapptemplate.nativeapptemplatefree.model.LoggedInShopkeeper
@@ -99,7 +99,7 @@ class SignInEmailAndPasswordViewModel @Inject constructor(
 
   fun hasInvalidDataPassword(): Boolean {
     if (uiState.value.password.isBlank()) return true
-    if (uiState.value.password.length < NatConstants.MINIMUM_PASSWORD_LENGTH) return true
+    if (uiState.value.password.length < NativeAppTemplateConstants.MINIMUM_PASSWORD_LENGTH) return true
 
     return false
   }

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/app_root/SignUpOrSignInView.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/app_root/SignUpOrSignInView.kt
@@ -35,7 +35,7 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.withLink
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
-import com.nativeapptemplate.nativeapptemplatefree.NatConstants
+import com.nativeapptemplate.nativeapptemplatefree.NativeAppTemplateConstants
 import com.nativeapptemplate.nativeapptemplatefree.R
 import com.nativeapptemplate.nativeapptemplatefree.ui.common.MainButtonView
 
@@ -85,7 +85,7 @@ internal fun SignUpOrSignInView(
 
         withLink(
           LinkAnnotation.Url(
-            NatConstants.TERMS_OF_USE_URL,
+            NativeAppTemplateConstants.TERMS_OF_USE_URL,
             TextLinkStyles(style = SpanStyle(color = MaterialTheme.colorScheme.primary)),
           ),
         ) {
@@ -98,7 +98,7 @@ internal fun SignUpOrSignInView(
 
         withLink(
           LinkAnnotation.Url(
-            NatConstants.PRIVACY_POLICY_URL,
+            NativeAppTemplateConstants.PRIVACY_POLICY_URL,
             TextLinkStyles(style = SpanStyle(color = MaterialTheme.colorScheme.primary)),
           ),
         ) {
@@ -155,7 +155,7 @@ private fun TopAppBar(
     title = { Text("") },
     actions = {
       TextButton(
-        onClick = { context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(NatConstants.SUPPORT_WEBSITE_URL))) },
+        onClick = { context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(NativeAppTemplateConstants.SUPPORT_WEBSITE_URL))) },
       ) {
         Text(
           stringResource(R.string.support_website),

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/app_root/SignUpView.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/app_root/SignUpView.kt
@@ -49,11 +49,11 @@ import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.nativeapptemplate.nativeapptemplatefree.NatConstants
+import com.nativeapptemplate.nativeapptemplatefree.NativeAppTemplateConstants
 import com.nativeapptemplate.nativeapptemplatefree.R
 import com.nativeapptemplate.nativeapptemplatefree.model.TimeZones
 import com.nativeapptemplate.nativeapptemplatefree.ui.common.LoadingView
-import com.nativeapptemplate.nativeapptemplatefree.ui.common.NatAlertDialog
+import com.nativeapptemplate.nativeapptemplatefree.ui.common.NativeAppTemplateAlertDialog
 import com.nativeapptemplate.nativeapptemplatefree.ui.common.SnackbarMessageEffect
 
 @Composable
@@ -71,7 +71,7 @@ fun SignUpView(
   )
 
   if (uiState.isCreated) {
-    NatAlertDialog(
+    NativeAppTemplateAlertDialog(
       dialogTitle = stringResource(R.string.signed_up_but_unconfirmed),
       onDismissRequest = { onBackClick() },
     )
@@ -154,7 +154,7 @@ fun SignUpContentView(
             text = stringResource(R.string.full_name),
           )
         },
-        placeholder = { Text(NatConstants.PLACEHOLDER_FULLNAME) },
+        placeholder = { Text(NativeAppTemplateConstants.PLACEHOLDER_FULLNAME) },
         value = uiState.name,
         onValueChange = { viewModel.updateName(it) },
         supportingText = {
@@ -174,7 +174,7 @@ fun SignUpContentView(
             text = stringResource(R.string.email),
           )
         },
-        placeholder = { Text(NatConstants.PLACEHOLDER_EMAIL) },
+        placeholder = { Text(NativeAppTemplateConstants.PLACEHOLDER_EMAIL) },
         value = uiState.email,
         onValueChange = { viewModel.updateEmail(it) },
         supportingText = {
@@ -234,13 +234,13 @@ fun SignUpContentView(
             text = stringResource(R.string.password),
           )
         },
-        placeholder = { Text(NatConstants.PLACEHOLDER_PASSWORD) },
+        placeholder = { Text(NativeAppTemplateConstants.PLACEHOLDER_PASSWORD) },
         value = uiState.password,
         onValueChange = { viewModel.updatePassword(it) },
         supportingText = {
           Column {
             Text(
-              text = "${NatConstants.MINIMUM_PASSWORD_LENGTH} characters minimum.",
+              text = "${NativeAppTemplateConstants.MINIMUM_PASSWORD_LENGTH} characters minimum.",
               style = MaterialTheme.typography.bodyLarge,
               color = MaterialTheme.colorScheme.onSurfaceVariant,
             )

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/app_root/SignUpViewModel.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/app_root/SignUpViewModel.kt
@@ -2,7 +2,7 @@ package com.nativeapptemplate.nativeapptemplatefree.ui.app_root
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.nativeapptemplate.nativeapptemplatefree.NatConstants
+import com.nativeapptemplate.nativeapptemplatefree.NativeAppTemplateConstants
 import com.nativeapptemplate.nativeapptemplatefree.common.errors.codedDescription
 import com.nativeapptemplate.nativeapptemplatefree.data.login.SignUpRepository
 import com.nativeapptemplate.nativeapptemplatefree.model.SignUp
@@ -93,7 +93,7 @@ class SignUpViewModel @Inject constructor(
 
   fun hasInvalidDataPassword(): Boolean {
     if (uiState.value.password.isBlank()) return true
-    if (uiState.value.password.length < NatConstants.MINIMUM_PASSWORD_LENGTH) return true
+    if (uiState.value.password.length < NativeAppTemplateConstants.MINIMUM_PASSWORD_LENGTH) return true
 
     return false
   }

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/common/ErrorView.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/common/ErrorView.kt
@@ -14,7 +14,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.nativeapptemplate.nativeapptemplatefree.designsystem.theme.NatTheme
+import com.nativeapptemplate.nativeapptemplatefree.designsystem.theme.NativeAppTemplateTheme
 
 @Composable
 fun ErrorView(
@@ -60,7 +60,7 @@ fun ErrorView(
 @Preview
 @Composable
 private fun LoadingStatePreview() {
-  NatTheme {
+  NativeAppTemplateTheme {
     ErrorView(
       onClick = {},
     )

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/common/LoadingView.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/common/LoadingView.kt
@@ -9,7 +9,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.nativeapptemplate.nativeapptemplatefree.designsystem.theme.NatTheme
+import com.nativeapptemplate.nativeapptemplatefree.designsystem.theme.NativeAppTemplateTheme
 
 @Composable
 fun LoadingView() {
@@ -28,7 +28,7 @@ fun LoadingView() {
 @Preview
 @Composable
 private fun LoadingStatePreview() {
-  NatTheme {
+  NativeAppTemplateTheme {
     LoadingView()
   }
 }

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/common/NativeAppTemplateAlertDialog.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/common/NativeAppTemplateAlertDialog.kt
@@ -13,7 +13,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
 
 @Composable
-fun NatAlertDialog(
+fun NativeAppTemplateAlertDialog(
   dialogTitle: String? = null,
   confirmButtonTitle: String? = null,
   onDismissRequest: (() -> Unit)? = null,

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/common/tags/CompletedTag.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/common/tags/CompletedTag.kt
@@ -3,7 +3,7 @@ package com.nativeapptemplate.nativeapptemplatefree.ui.common.tags
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import com.nativeapptemplate.nativeapptemplatefree.designsystem.theme.LocalCustomColorScheme
-import com.nativeapptemplate.nativeapptemplatefree.designsystem.theme.NatTheme
+import com.nativeapptemplate.nativeapptemplatefree.designsystem.theme.NativeAppTemplateTheme
 
 @Composable
 fun CompletedTag() {
@@ -17,7 +17,7 @@ fun CompletedTag() {
 @Preview
 @Composable
 private fun CompletedTagPreview() {
-  NatTheme {
+  NativeAppTemplateTheme {
     CompletedTag()
   }
 }

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/common/tags/IdlingTag.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/common/tags/IdlingTag.kt
@@ -3,7 +3,7 @@ package com.nativeapptemplate.nativeapptemplatefree.ui.common.tags
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
-import com.nativeapptemplate.nativeapptemplatefree.designsystem.theme.NatTheme
+import com.nativeapptemplate.nativeapptemplatefree.designsystem.theme.NativeAppTemplateTheme
 
 @Composable
 fun IdlingTag() {
@@ -17,7 +17,7 @@ fun IdlingTag() {
 @Preview
 @Composable
 private fun IdlingTagPreview() {
-  NatTheme {
+  NativeAppTemplateTheme {
     IdlingTag()
   }
 }

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/common/tags/TagView.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/common/tags/TagView.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.nativeapptemplate.nativeapptemplatefree.designsystem.theme.NatTheme
+import com.nativeapptemplate.nativeapptemplatefree.designsystem.theme.NativeAppTemplateTheme
 import com.nativeapptemplate.nativeapptemplatefree.ui.common.NonScaledSp.nonScaledSp
 
 @Composable
@@ -46,7 +46,7 @@ fun TagView(
 @Preview
 @Composable
 private fun TagViewPreview() {
-  NatTheme {
+  NativeAppTemplateTheme {
     TagView(
       text = "COMPLETE",
       textColor = MaterialTheme.colorScheme.onError,

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/settings/DarkModeSettingsDialog.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/settings/DarkModeSettingsDialog.kt
@@ -30,7 +30,7 @@ import androidx.compose.ui.window.DialogProperties
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.nativeapptemplate.nativeapptemplatefree.R
-import com.nativeapptemplate.nativeapptemplatefree.designsystem.theme.NatTheme
+import com.nativeapptemplate.nativeapptemplatefree.designsystem.theme.NativeAppTemplateTheme
 import com.nativeapptemplate.nativeapptemplatefree.model.DarkThemeConfig
 
 @Composable
@@ -158,7 +158,7 @@ fun SettingsDialogThemeChooserRow(
 @Preview
 @Composable
 private fun PreviewSettingsDialog() {
-  NatTheme {
+  NativeAppTemplateTheme {
     DarkModeSettingsDialog(
       onDismiss = {},
       settingsUiState = DarkModeSettingsUiState.Success(
@@ -174,7 +174,7 @@ private fun PreviewSettingsDialog() {
 @Preview
 @Composable
 private fun PreviewSettingsDialogLoading() {
-  NatTheme {
+  NativeAppTemplateTheme {
     DarkModeSettingsDialog(
       onDismiss = {},
       settingsUiState = DarkModeSettingsUiState.Loading,

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/settings/PasswordEditView.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/settings/PasswordEditView.kt
@@ -44,7 +44,7 @@ import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.nativeapptemplate.nativeapptemplatefree.NatConstants
+import com.nativeapptemplate.nativeapptemplatefree.NativeAppTemplateConstants
 import com.nativeapptemplate.nativeapptemplatefree.R
 import com.nativeapptemplate.nativeapptemplatefree.ui.common.LoadingView
 import com.nativeapptemplate.nativeapptemplatefree.ui.common.SnackbarMessageEffect
@@ -190,7 +190,7 @@ fun PasswordEditContentView(
         supportingText = {
           Column {
             Text(
-              text = "${NatConstants.MINIMUM_PASSWORD_LENGTH} characters minimum.",
+              text = "${NativeAppTemplateConstants.MINIMUM_PASSWORD_LENGTH} characters minimum.",
               style = MaterialTheme.typography.bodyLarge,
               color = MaterialTheme.colorScheme.onSurfaceVariant,
             )

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/settings/PasswordEditViewModel.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/settings/PasswordEditViewModel.kt
@@ -2,7 +2,7 @@ package com.nativeapptemplate.nativeapptemplatefree.ui.settings
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.nativeapptemplate.nativeapptemplatefree.NatConstants
+import com.nativeapptemplate.nativeapptemplatefree.NativeAppTemplateConstants
 import com.nativeapptemplate.nativeapptemplatefree.common.errors.codedDescription
 import com.nativeapptemplate.nativeapptemplatefree.data.login.AccountPasswordRepository
 import com.nativeapptemplate.nativeapptemplatefree.model.UpdatePasswordBody
@@ -89,7 +89,7 @@ class PasswordEditViewModel @Inject constructor(
 
   fun hasInvalidDataPassword(): Boolean {
     if (uiState.value.password.isBlank()) return true
-    if (uiState.value.password.length < NatConstants.MINIMUM_PASSWORD_LENGTH) return true
+    if (uiState.value.password.length < NativeAppTemplateConstants.MINIMUM_PASSWORD_LENGTH) return true
 
     return false
   }

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/settings/SettingsView.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/settings/SettingsView.kt
@@ -46,7 +46,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.nativeapptemplate.nativeapptemplatefree.BuildConfig
-import com.nativeapptemplate.nativeapptemplatefree.NatConstants
+import com.nativeapptemplate.nativeapptemplatefree.NativeAppTemplateConstants
 import com.nativeapptemplate.nativeapptemplatefree.R
 import com.nativeapptemplate.nativeapptemplatefree.model.DarkThemeConfig
 import com.nativeapptemplate.nativeapptemplatefree.ui.common.ErrorView
@@ -280,7 +280,7 @@ private fun SettingsContentView(
             },
             modifier = Modifier
               .clickable {
-                context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(NatConstants.FAQS_URL)))
+                context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(NativeAppTemplateConstants.FAQS_URL)))
               },
           )
           HorizontalDivider()
@@ -384,7 +384,7 @@ private fun SettingsContentView(
                 context.startActivity(
                   Intent(
                     Intent.ACTION_VIEW,
-                    Uri.parse(NatConstants.SUPPORT_WEBSITE_URL),
+                    Uri.parse(NativeAppTemplateConstants.SUPPORT_WEBSITE_URL),
                   ),
                 )
               },
@@ -412,7 +412,7 @@ private fun SettingsContentView(
                 context.startActivity(
                   Intent(
                     Intent.ACTION_VIEW,
-                    Uri.parse(NatConstants.PRIVACY_POLICY_URL),
+                    Uri.parse(NativeAppTemplateConstants.PRIVACY_POLICY_URL),
                   ),
                 )
               },
@@ -440,7 +440,7 @@ private fun SettingsContentView(
                 context.startActivity(
                   Intent(
                     Intent.ACTION_VIEW,
-                    Uri.parse(NatConstants.TERMS_OF_USE_URL),
+                    Uri.parse(NativeAppTemplateConstants.TERMS_OF_USE_URL),
                   ),
                 )
               },

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/settings/ShopkeeperEditView.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/settings/ShopkeeperEditView.kt
@@ -52,7 +52,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.nativeapptemplate.nativeapptemplatefree.NatConstants
+import com.nativeapptemplate.nativeapptemplatefree.NativeAppTemplateConstants
 import com.nativeapptemplate.nativeapptemplatefree.R
 import com.nativeapptemplate.nativeapptemplatefree.model.TimeZones
 import com.nativeapptemplate.nativeapptemplatefree.ui.common.ErrorView
@@ -170,7 +170,7 @@ fun ShopkeeperEditContentView(
             text = stringResource(R.string.full_name),
           )
         },
-        placeholder = { Text(NatConstants.PLACEHOLDER_FULLNAME) },
+        placeholder = { Text(NativeAppTemplateConstants.PLACEHOLDER_FULLNAME) },
         value = uiState.name,
         onValueChange = { viewModel.updateName(it) },
         supportingText = {
@@ -190,7 +190,7 @@ fun ShopkeeperEditContentView(
             text = stringResource(R.string.email),
           )
         },
-        placeholder = { Text(NatConstants.PLACEHOLDER_EMAIL) },
+        placeholder = { Text(NativeAppTemplateConstants.PLACEHOLDER_EMAIL) },
         value = uiState.email,
         onValueChange = { viewModel.updateEmail(it) },
         supportingText = {

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/ShopBasicSettingsViewModel.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/ShopBasicSettingsViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
-import com.nativeapptemplate.nativeapptemplatefree.NatConstants
+import com.nativeapptemplate.nativeapptemplatefree.NativeAppTemplateConstants
 import com.nativeapptemplate.nativeapptemplatefree.common.errors.codedDescription
 import com.nativeapptemplate.nativeapptemplatefree.data.shop.ShopRepository
 import com.nativeapptemplate.nativeapptemplatefree.model.Shop
@@ -28,8 +28,8 @@ data class ShopBasicSettingsUiState(
   val name: String = "",
   val description: String = "",
   val timeZone: String = TimeZones.DEFAULT_TIME_ZONE,
-  val maximumNameLength: Int = NatConstants.MAXIMUM_SHOP_NAME_LENGTH,
-  val maximumDescriptionLength: Int = NatConstants.MAXIMUM_SHOP_DESCRIPTION_LENGTH,
+  val maximumNameLength: Int = NativeAppTemplateConstants.MAXIMUM_SHOP_NAME_LENGTH,
+  val maximumDescriptionLength: Int = NativeAppTemplateConstants.MAXIMUM_SHOP_DESCRIPTION_LENGTH,
 
   val isLoading: Boolean = true,
   val success: Boolean = false,

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/ShopSettingsView.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/ShopSettingsView.kt
@@ -42,7 +42,7 @@ import com.nativeapptemplate.nativeapptemplatefree.R
 import com.nativeapptemplate.nativeapptemplatefree.ui.common.ErrorView
 import com.nativeapptemplate.nativeapptemplatefree.ui.common.LoadingView
 import com.nativeapptemplate.nativeapptemplatefree.ui.common.MainButtonView
-import com.nativeapptemplate.nativeapptemplatefree.ui.common.NatAlertDialog
+import com.nativeapptemplate.nativeapptemplatefree.ui.common.NativeAppTemplateAlertDialog
 import com.nativeapptemplate.nativeapptemplatefree.ui.common.SnackbarMessageEffect
 import com.nativeapptemplate.nativeapptemplatefree.utils.Utility.restartApp
 
@@ -145,7 +145,7 @@ private fun ShopSettingsContentView(
   var isShowingDeleteConfirmationDialog by remember { mutableStateOf(false) }
 
   if (isShowingDeleteConfirmationDialog) {
-    NatAlertDialog(
+    NativeAppTemplateAlertDialog(
       dialogTitle = stringResource(R.string.are_you_sure),
       confirmButtonTitle = stringResource(R.string.title_delete_shop),
       onDismissRequest = { isShowingDeleteConfirmationDialog = false },

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/item_tag_detail/ItemTagDetailView.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/item_tag_detail/ItemTagDetailView.kt
@@ -43,7 +43,7 @@ import com.nativeapptemplate.nativeapptemplatefree.model.ItemTagState
 import com.nativeapptemplate.nativeapptemplatefree.ui.common.ErrorView
 import com.nativeapptemplate.nativeapptemplatefree.ui.common.LoadingView
 import com.nativeapptemplate.nativeapptemplatefree.ui.common.MainButtonView
-import com.nativeapptemplate.nativeapptemplatefree.ui.common.NatAlertDialog
+import com.nativeapptemplate.nativeapptemplatefree.ui.common.NativeAppTemplateAlertDialog
 import com.nativeapptemplate.nativeapptemplatefree.ui.common.SnackbarMessageEffect
 import com.nativeapptemplate.nativeapptemplatefree.ui.common.tags.CompletedTag
 import com.nativeapptemplate.nativeapptemplatefree.ui.common.tags.IdlingTag
@@ -69,7 +69,7 @@ internal fun ItemTagDetailView(
   )
 
   if (uiState.isDeleted) {
-    NatAlertDialog(
+    NativeAppTemplateAlertDialog(
       dialogTitle = stringResource(R.string.message_item_tag_deleted),
       onDismissRequest = { onBackClick() },
     )
@@ -137,7 +137,7 @@ private fun ItemTagDetailContentView(
   var isShowingDeleteConfirmationDialog by remember { mutableStateOf(false) }
 
   if (isShowingDeleteConfirmationDialog) {
-    NatAlertDialog(
+    NativeAppTemplateAlertDialog(
       dialogTitle = stringResource(R.string.are_you_sure),
       confirmButtonTitle = stringResource(R.string.title_delete_item_tag),
       onDismissRequest = { isShowingDeleteConfirmationDialog = false },

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/item_tag_detail/ItemTagEditView.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/item_tag_detail/ItemTagEditView.kt
@@ -37,7 +37,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.nativeapptemplate.nativeapptemplatefree.NatConstants
+import com.nativeapptemplate.nativeapptemplatefree.NativeAppTemplateConstants
 import com.nativeapptemplate.nativeapptemplatefree.R
 import com.nativeapptemplate.nativeapptemplatefree.ui.common.ErrorView
 import com.nativeapptemplate.nativeapptemplatefree.ui.common.LoadingView
@@ -170,7 +170,7 @@ fun ItemTagEditContentView(
         supportingText = {
           Column {
             Text(
-              text = stringResource(R.string.item_tag_description_help, NatConstants.MAXIMUM_ITEM_TAG_DESCRIPTION_LENGTH),
+              text = stringResource(R.string.item_tag_description_help, NativeAppTemplateConstants.MAXIMUM_ITEM_TAG_DESCRIPTION_LENGTH),
               style = MaterialTheme.typography.bodyLarge,
               color = MaterialTheme.colorScheme.onSurfaceVariant,
             )

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/item_tag_detail/ItemTagEditViewModel.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/item_tag_detail/ItemTagEditViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
-import com.nativeapptemplate.nativeapptemplatefree.NatConstants
+import com.nativeapptemplate.nativeapptemplatefree.NativeAppTemplateConstants
 import com.nativeapptemplate.nativeapptemplatefree.common.errors.codedDescription
 import com.nativeapptemplate.nativeapptemplatefree.data.item_tag.ItemTagRepository
 import com.nativeapptemplate.nativeapptemplatefree.model.ItemTag
@@ -26,7 +26,7 @@ data class ItemTagEditUiState(
 
   val name: String = "",
   val description: String = "",
-  val maximumNameLength: Int = NatConstants.MAXIMUM_ITEM_TAG_NAME_LENGTH,
+  val maximumNameLength: Int = NativeAppTemplateConstants.MAXIMUM_ITEM_TAG_NAME_LENGTH,
   val isUpdated: Boolean = false,
 
   val isLoading: Boolean = true,
@@ -143,7 +143,7 @@ class ItemTagEditViewModel @Inject constructor(
   }
 
   fun hasInvalidDataDescription(): Boolean {
-    return uiState.value.description.length > NatConstants.MAXIMUM_ITEM_TAG_DESCRIPTION_LENGTH
+    return uiState.value.description.length > NativeAppTemplateConstants.MAXIMUM_ITEM_TAG_DESCRIPTION_LENGTH
   }
 
   fun updateName(newName: String) {
@@ -156,7 +156,7 @@ class ItemTagEditViewModel @Inject constructor(
   }
 
   fun updateDescription(newDescription: String) {
-    if (newDescription.length > NatConstants.MAXIMUM_ITEM_TAG_DESCRIPTION_LENGTH) return
+    if (newDescription.length > NativeAppTemplateConstants.MAXIMUM_ITEM_TAG_DESCRIPTION_LENGTH) return
 
     _uiState.update {
       it.copy(description = newDescription)

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/item_tag_list/ItemTagCreateView.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/item_tag_list/ItemTagCreateView.kt
@@ -36,11 +36,11 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.nativeapptemplate.nativeapptemplatefree.NatConstants
+import com.nativeapptemplate.nativeapptemplatefree.NativeAppTemplateConstants
 import com.nativeapptemplate.nativeapptemplatefree.R
 import com.nativeapptemplate.nativeapptemplatefree.ui.common.ErrorView
 import com.nativeapptemplate.nativeapptemplatefree.ui.common.LoadingView
-import com.nativeapptemplate.nativeapptemplatefree.ui.common.NatAlertDialog
+import com.nativeapptemplate.nativeapptemplatefree.ui.common.NativeAppTemplateAlertDialog
 import com.nativeapptemplate.nativeapptemplatefree.ui.common.SnackbarMessageEffect
 
 @Composable
@@ -62,7 +62,7 @@ fun ItemTagCreateView(
   )
 
   if (uiState.isCreated) {
-    NatAlertDialog(
+    NativeAppTemplateAlertDialog(
       dialogTitle = stringResource(R.string.message_item_tag_created),
       onDismissRequest = { onBackClick() },
     )
@@ -170,7 +170,7 @@ fun ItemTagCreateContentView(
         supportingText = {
           Column {
             Text(
-              text = stringResource(R.string.item_tag_description_help, NatConstants.MAXIMUM_ITEM_TAG_DESCRIPTION_LENGTH),
+              text = stringResource(R.string.item_tag_description_help, NativeAppTemplateConstants.MAXIMUM_ITEM_TAG_DESCRIPTION_LENGTH),
               style = MaterialTheme.typography.bodyLarge,
               color = MaterialTheme.colorScheme.onSurfaceVariant,
             )

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/item_tag_list/ItemTagCreateViewModel.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/item_tag_list/ItemTagCreateViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
-import com.nativeapptemplate.nativeapptemplatefree.NatConstants
+import com.nativeapptemplate.nativeapptemplatefree.NativeAppTemplateConstants
 import com.nativeapptemplate.nativeapptemplatefree.common.errors.codedDescription
 import com.nativeapptemplate.nativeapptemplatefree.data.item_tag.ItemTagRepository
 import com.nativeapptemplate.nativeapptemplatefree.model.ItemTag
@@ -24,7 +24,7 @@ import javax.inject.Inject
 data class ItemTagCreateUiState(
   val name: String = "",
   val description: String = "",
-  val maximumNameLength: Int = NatConstants.MAXIMUM_ITEM_TAG_NAME_LENGTH,
+  val maximumNameLength: Int = NativeAppTemplateConstants.MAXIMUM_ITEM_TAG_NAME_LENGTH,
   val isCreated: Boolean = false,
 
   val isLoading: Boolean = false,
@@ -99,7 +99,7 @@ class ItemTagCreateViewModel @Inject constructor(
   }
 
   fun hasInvalidDataDescription(): Boolean {
-    return uiState.value.description.length > NatConstants.MAXIMUM_ITEM_TAG_DESCRIPTION_LENGTH
+    return uiState.value.description.length > NativeAppTemplateConstants.MAXIMUM_ITEM_TAG_DESCRIPTION_LENGTH
   }
 
   fun updateName(newName: String) {
@@ -112,7 +112,7 @@ class ItemTagCreateViewModel @Inject constructor(
   }
 
   fun updateDescription(newDescription: String) {
-    if (newDescription.length > NatConstants.MAXIMUM_ITEM_TAG_DESCRIPTION_LENGTH) return
+    if (newDescription.length > NativeAppTemplateConstants.MAXIMUM_ITEM_TAG_DESCRIPTION_LENGTH) return
 
     _uiState.update {
       it.copy(description = newDescription)

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shops/ShopCreateView.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shops/ShopCreateView.kt
@@ -47,7 +47,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.nativeapptemplate.nativeapptemplatefree.R
 import com.nativeapptemplate.nativeapptemplatefree.model.TimeZones
 import com.nativeapptemplate.nativeapptemplatefree.ui.common.LoadingView
-import com.nativeapptemplate.nativeapptemplatefree.ui.common.NatAlertDialog
+import com.nativeapptemplate.nativeapptemplatefree.ui.common.NativeAppTemplateAlertDialog
 import com.nativeapptemplate.nativeapptemplatefree.ui.common.SnackbarMessageEffect
 
 @Composable
@@ -64,7 +64,7 @@ fun ShopCreateView(
   )
 
   if (uiState.isCreated) {
-    NatAlertDialog(
+    NativeAppTemplateAlertDialog(
       dialogTitle = stringResource(R.string.message_shop_created),
       onDismissRequest = { onBackClick() },
     )

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shops/ShopCreateViewModel.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shops/ShopCreateViewModel.kt
@@ -2,7 +2,7 @@ package com.nativeapptemplate.nativeapptemplatefree.ui.shops
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.nativeapptemplate.nativeapptemplatefree.NatConstants
+import com.nativeapptemplate.nativeapptemplatefree.NativeAppTemplateConstants
 import com.nativeapptemplate.nativeapptemplatefree.common.errors.codedDescription
 import com.nativeapptemplate.nativeapptemplatefree.data.shop.ShopRepository
 import com.nativeapptemplate.nativeapptemplatefree.model.Shop
@@ -23,8 +23,8 @@ data class ShopCreateUiState(
   val name: String = "",
   val description: String = "",
   val timeZone: String = TimeZones.currentTimeZoneKey(),
-  val maximumNameLength: Int = NatConstants.MAXIMUM_SHOP_NAME_LENGTH,
-  val maximumDescriptionLength: Int = NatConstants.MAXIMUM_SHOP_DESCRIPTION_LENGTH,
+  val maximumNameLength: Int = NativeAppTemplateConstants.MAXIMUM_SHOP_NAME_LENGTH,
+  val maximumDescriptionLength: Int = NativeAppTemplateConstants.MAXIMUM_SHOP_DESCRIPTION_LENGTH,
 
   val isLoading: Boolean = false,
   val isCreated: Boolean = false,

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/utils/Utility.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/utils/Utility.kt
@@ -7,7 +7,7 @@ import android.net.Uri
 import android.os.Build
 import androidx.activity.ComponentActivity
 import com.nativeapptemplate.nativeapptemplatefree.BuildConfig
-import com.nativeapptemplate.nativeapptemplatefree.NatConstants
+import com.nativeapptemplate.nativeapptemplatefree.NativeAppTemplateConstants
 import com.nativeapptemplate.nativeapptemplatefree.R
 import java.util.Locale
 
@@ -52,7 +52,7 @@ object Utility {
 
     val emailIntent = Intent(Intent.ACTION_SENDTO)
 
-    val uriText = "mailto:" + Uri.encode(NatConstants.SUPPORT_MAIL) +
+    val uriText = "mailto:" + Uri.encode(NativeAppTemplateConstants.SUPPORT_MAIL) +
       "?subject=" + Uri.encode("$appName for Android support") +
       "&body=" + Uri.encode(body)
 

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -16,7 +16,7 @@
 -->
 <resources xmlns:tools="http://schemas.android.com/tools">
 
-    <style name="NightAdjusted.Theme.Nat" parent="android:Theme.Material.NoActionBar" />
+    <style name="NightAdjusted.Theme.NativeAppTemplate" parent="android:Theme.Material.NoActionBar" />
 
     <style name="NightAdjusted.Theme.Splash" parent="Theme.SplashScreen">
         <item name="android:windowLightStatusBar" >false</item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -18,19 +18,19 @@
 
     <!-- Allows us to override night specific attributes in the
          values-night folder. -->
-    <style name="NightAdjusted.Theme.Nat" parent="android:Theme.Material.Light.NoActionBar" />
+    <style name="NightAdjusted.Theme.NativeAppTemplate" parent="android:Theme.Material.Light.NoActionBar" />
 
     <!-- The final theme we use -->
-    <style name="Theme.Nat" parent="NightAdjusted.Theme.Nat" />
+    <style name="Theme.NativeAppTemplate" parent="NightAdjusted.Theme.NativeAppTemplate" />
 
     <style name="NightAdjusted.Theme.Splash" parent="Theme.SplashScreen">
         <item name="android:windowLightStatusBar" >true</item>
         <item name="android:windowLightNavigationBar" tools:targetApi="27">true</item>
     </style>
 
-    <style name="Theme.Nat.Splash" parent="NightAdjusted.Theme.Splash">
+    <style name="Theme.NativeAppTemplate.Splash" parent="NightAdjusted.Theme.Splash">
         <item name="windowSplashScreenAnimatedIcon">@drawable/ic_splash</item>
-        <item name="postSplashScreenTheme">@style/Theme.Nat</item>
+        <item name="postSplashScreenTheme">@style/Theme.NativeAppTemplate</item>
     </style>
 
 </resources>

--- a/app/src/test/kotlin/com/nativeapptemplate/nativeapptemplatefree/common/errors/CodedErrorTest.kt
+++ b/app/src/test/kotlin/com/nativeapptemplate/nativeapptemplatefree/common/errors/CodedErrorTest.kt
@@ -8,44 +8,44 @@ class CodedErrorTest {
   @Test
   fun apiError_hasCorrectErrorCode() {
     val error = ApiException.ApiError(code = 422, apiMessage = "Validation failed")
-    assertEquals("NATA-2001", error.errorCode)
+    assertEquals("NATIVEAPPTEMPLATE-2001", error.errorCode)
   }
 
   @Test
   fun apiError_formattedDescription_includesCodeAndMessage() {
     val error = ApiException.ApiError(code = 422, apiMessage = "Validation failed")
-    assertEquals("[NATA-2001] Validation failed [Status: 422]", error.formattedDescription)
+    assertEquals("[NATIVEAPPTEMPLATE-2001] Validation failed [Status: 422]", error.formattedDescription)
   }
 
   @Test
   fun unprocessableError_hasCorrectErrorCode() {
     val error = ApiException.UnprocessableError(rawMessage = "timeout")
-    assertEquals("NATA-2002", error.errorCode)
+    assertEquals("NATIVEAPPTEMPLATE-2002", error.errorCode)
   }
 
   @Test
   fun unprocessableError_formattedDescription_includesCodeAndMessage() {
     val error = ApiException.UnprocessableError(rawMessage = "timeout")
-    assertEquals("[NATA-2002] Processing error: timeout", error.formattedDescription)
+    assertEquals("[NATIVEAPPTEMPLATE-2002] Processing error: timeout", error.formattedDescription)
   }
 
   @Test
   fun appError_unexpected_hasCorrectCode() {
     val error = AppError.Unexpected()
-    assertEquals("NATA-1001", error.errorCode)
-    assertEquals("[NATA-1001] Unexpected error", error.formattedDescription)
+    assertEquals("NATIVEAPPTEMPLATE-1001", error.errorCode)
+    assertEquals("[NATIVEAPPTEMPLATE-1001] Unexpected error", error.formattedDescription)
   }
 
   @Test
   fun appError_unexpected_withDetail_includesDetail() {
     val error = AppError.Unexpected(detail = "null pointer")
-    assertEquals("[NATA-1001] Unexpected error: null pointer", error.formattedDescription)
+    assertEquals("[NATIVEAPPTEMPLATE-1001] Unexpected error: null pointer", error.formattedDescription)
   }
 
   @Test
   fun codedDescription_forCodedError_returnsFormattedDescription() {
     val error: Throwable = ApiException.ApiError(code = 500, apiMessage = "Server error")
-    assertEquals("[NATA-2001] Server error [Status: 500]", error.codedDescription)
+    assertEquals("[NATIVEAPPTEMPLATE-2001] Server error [Status: 500]", error.codedDescription)
   }
 
   @Test

--- a/app/src/test/kotlin/com/nativeapptemplate/nativeapptemplatefree/datastore/NativeAppTemplatePreferencesDataSourceTest.kt
+++ b/app/src/test/kotlin/com/nativeapptemplate/nativeapptemplatefree/datastore/NativeAppTemplatePreferencesDataSourceTest.kt
@@ -13,14 +13,14 @@ import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
 
-class NatPreferencesDataSourceTest {
+class NativeAppTemplatePreferencesDataSourceTest {
   private val testScope = TestScope(UnconfinedTestDispatcher())
 
-  private lateinit var subject: NatPreferencesDataSource
+  private lateinit var subject: NativeAppTemplatePreferencesDataSource
 
   @Before
   fun setup() {
-    subject = NatPreferencesDataSource(InMemoryDataStore(UserPreferences.getDefaultInstance()))
+    subject = NativeAppTemplatePreferencesDataSource(InMemoryDataStore(UserPreferences.getDefaultInstance()))
   }
 
   @Test

--- a/app/src/test/kotlin/com/nativeapptemplate/nativeapptemplatefree/demo/item_tag/DemoItemTagRepository.kt
+++ b/app/src/test/kotlin/com/nativeapptemplate/nativeapptemplatefree/demo/item_tag/DemoItemTagRepository.kt
@@ -9,7 +9,7 @@ import com.nativeapptemplate.nativeapptemplatefree.model.ItemTag
 import com.nativeapptemplate.nativeapptemplatefree.model.ItemTagBody
 import com.nativeapptemplate.nativeapptemplatefree.model.ItemTags
 import com.nativeapptemplate.nativeapptemplatefree.network.Dispatcher
-import com.nativeapptemplate.nativeapptemplatefree.network.NatDispatchers
+import com.nativeapptemplate.nativeapptemplatefree.network.NativeAppTemplateDispatchers
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -22,7 +22,7 @@ import kotlinx.serialization.json.decodeFromStream
 import javax.inject.Inject
 
 class DemoItemTagRepository @Inject constructor(
-  @Dispatcher(NatDispatchers.IO) private val ioDispatcher: CoroutineDispatcher,
+  @Dispatcher(NativeAppTemplateDispatchers.IO) private val ioDispatcher: CoroutineDispatcher,
   private val networkJson: Json,
   private val assets: DemoAssetManager = DemoAssetManagerImpl,
 ) : ItemTagRepository {

--- a/app/src/test/kotlin/com/nativeapptemplate/nativeapptemplatefree/demo/login/DemoLoginRepository.kt
+++ b/app/src/test/kotlin/com/nativeapptemplate/nativeapptemplatefree/demo/login/DemoLoginRepository.kt
@@ -11,7 +11,7 @@ import com.nativeapptemplate.nativeapptemplatefree.model.Login
 import com.nativeapptemplate.nativeapptemplatefree.model.Permissions
 import com.nativeapptemplate.nativeapptemplatefree.model.UserData
 import com.nativeapptemplate.nativeapptemplatefree.network.Dispatcher
-import com.nativeapptemplate.nativeapptemplatefree.network.NatDispatchers
+import com.nativeapptemplate.nativeapptemplatefree.network.NativeAppTemplateDispatchers
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST
 import kotlinx.coroutines.flow.Flow
@@ -27,7 +27,7 @@ import kotlinx.serialization.json.decodeFromStream
 import javax.inject.Inject
 
 class DemoLoginRepository @Inject constructor(
-  @Dispatcher(NatDispatchers.IO) private val ioDispatcher: CoroutineDispatcher,
+  @Dispatcher(NativeAppTemplateDispatchers.IO) private val ioDispatcher: CoroutineDispatcher,
   private val networkJson: Json,
   private val assets: DemoAssetManager = DemoAssetManagerImpl,
 ) : LoginRepository {

--- a/app/src/test/kotlin/com/nativeapptemplate/nativeapptemplatefree/demo/login/DemoSignUpRepository.kt
+++ b/app/src/test/kotlin/com/nativeapptemplate/nativeapptemplatefree/demo/login/DemoSignUpRepository.kt
@@ -11,7 +11,7 @@ import com.nativeapptemplate.nativeapptemplatefree.model.SendResetPassword
 import com.nativeapptemplate.nativeapptemplatefree.model.SignUp
 import com.nativeapptemplate.nativeapptemplatefree.model.SignUpForUpdate
 import com.nativeapptemplate.nativeapptemplatefree.network.Dispatcher
-import com.nativeapptemplate.nativeapptemplatefree.network.NatDispatchers
+import com.nativeapptemplate.nativeapptemplatefree.network.NativeAppTemplateDispatchers
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -24,7 +24,7 @@ import kotlinx.serialization.json.decodeFromStream
 import javax.inject.Inject
 
 class DemoSignUpRepository @Inject constructor(
-  @Dispatcher(NatDispatchers.IO) private val ioDispatcher: CoroutineDispatcher,
+  @Dispatcher(NativeAppTemplateDispatchers.IO) private val ioDispatcher: CoroutineDispatcher,
   private val networkJson: Json,
   private val assets: DemoAssetManager = DemoAssetManagerImpl,
 ) : SignUpRepository {

--- a/app/src/test/kotlin/com/nativeapptemplate/nativeapptemplatefree/demo/login/DemoSignUpRepositoryTest.kt
+++ b/app/src/test/kotlin/com/nativeapptemplate/nativeapptemplatefree/demo/login/DemoSignUpRepositoryTest.kt
@@ -1,6 +1,6 @@
 package com.nativeapptemplate.nativeapptemplatefree.demo.login
 
-import com.nativeapptemplate.nativeapptemplatefree.NatConstants
+import com.nativeapptemplate.nativeapptemplatefree.NativeAppTemplateConstants
 import com.nativeapptemplate.nativeapptemplatefree.demo.DemoAssetManagerImpl
 import com.nativeapptemplate.nativeapptemplatefree.model.Attributes
 import com.nativeapptemplate.nativeapptemplatefree.model.Data
@@ -88,7 +88,7 @@ class DemoSignUpRepositoryTest {
       subject.sendResetPasswordInstruction(
         SendResetPassword(
           email = "john@example.com",
-          redirectUrl = SendResetPassword.redirectUrlString(NatConstants.baseUrlString()),
+          redirectUrl = SendResetPassword.redirectUrlString(NativeAppTemplateConstants.baseUrlString()),
         ),
       ).first(),
     )
@@ -100,7 +100,7 @@ class DemoSignUpRepositoryTest {
       subject.sendConfirmationInstruction(
         SendConfirmation(
           email = "john@example.com",
-          redirectUrl = SendConfirmation.redirectUrlString(NatConstants.baseUrlString()),
+          redirectUrl = SendConfirmation.redirectUrlString(NativeAppTemplateConstants.baseUrlString()),
         ),
       ).first(),
     )

--- a/app/src/test/kotlin/com/nativeapptemplate/nativeapptemplatefree/demo/shop/DemoShopRepository.kt
+++ b/app/src/test/kotlin/com/nativeapptemplate/nativeapptemplatefree/demo/shop/DemoShopRepository.kt
@@ -10,7 +10,7 @@ import com.nativeapptemplate.nativeapptemplatefree.model.ShopBody
 import com.nativeapptemplate.nativeapptemplatefree.model.ShopUpdateBody
 import com.nativeapptemplate.nativeapptemplatefree.model.Shops
 import com.nativeapptemplate.nativeapptemplatefree.network.Dispatcher
-import com.nativeapptemplate.nativeapptemplatefree.network.NatDispatchers
+import com.nativeapptemplate.nativeapptemplatefree.network.NativeAppTemplateDispatchers
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -23,7 +23,7 @@ import kotlinx.serialization.json.decodeFromStream
 import javax.inject.Inject
 
 class DemoShopRepository @Inject constructor(
-  @Dispatcher(NatDispatchers.IO) private val ioDispatcher: CoroutineDispatcher,
+  @Dispatcher(NativeAppTemplateDispatchers.IO) private val ioDispatcher: CoroutineDispatcher,
   private val networkJson: Json,
   private val assets: DemoAssetManager = DemoAssetManagerImpl,
 ) : ShopRepository {

--- a/app/src/test/kotlin/com/nativeapptemplate/nativeapptemplatefree/network/AuthInterceptorTest.kt
+++ b/app/src/test/kotlin/com/nativeapptemplate/nativeapptemplatefree/network/AuthInterceptorTest.kt
@@ -1,7 +1,7 @@
 package com.nativeapptemplate.nativeapptemplatefree.network
 
 import com.nativeapptemplate.nativeapptemplatefree.UserPreferences
-import com.nativeapptemplate.nativeapptemplatefree.datastore.NatPreferencesDataSource
+import com.nativeapptemplate.nativeapptemplatefree.datastore.NativeAppTemplatePreferencesDataSource
 import com.nativeapptemplate.nativeapptemplatefree.datastoreTest.InMemoryDataStore
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -26,14 +26,14 @@ class AuthInterceptorTest {
     client: String,
     uid: String,
     expiry: String,
-  ): NatPreferencesDataSource {
+  ): NativeAppTemplatePreferencesDataSource {
     val initial = UserPreferences.newBuilder()
       .setToken(token)
       .setClient(client)
       .setUid(uid)
       .setExpiry(expiry)
       .build()
-    return NatPreferencesDataSource(InMemoryDataStore(initial))
+    return NativeAppTemplatePreferencesDataSource(InMemoryDataStore(initial))
   }
 
   @Test
@@ -78,7 +78,7 @@ class AuthInterceptorTest {
 
   @Test
   fun intercept_withoutAuthData_omitsAuthHeaders() = testScope.runTest {
-    val dataSource = NatPreferencesDataSource(
+    val dataSource = NativeAppTemplatePreferencesDataSource(
       InMemoryDataStore(UserPreferences.getDefaultInstance()),
     )
     val interceptor = AuthInterceptor(dataSource)
@@ -97,7 +97,7 @@ class AuthInterceptorTest {
 
   @Test
   fun intercept_preservesOriginalRequestUrl() = testScope.runTest {
-    val dataSource = NatPreferencesDataSource(
+    val dataSource = NativeAppTemplatePreferencesDataSource(
       InMemoryDataStore(UserPreferences.getDefaultInstance()),
     )
     val interceptor = AuthInterceptor(dataSource)

--- a/app/src/test/kotlin/com/nativeapptemplate/nativeapptemplatefree/testing/di/TestDispatchersModule.kt
+++ b/app/src/test/kotlin/com/nativeapptemplate/nativeapptemplatefree/testing/di/TestDispatchersModule.kt
@@ -18,7 +18,7 @@ package com.nativeapptemplate.nativeapptemplatefree.testing.di
 
 import com.nativeapptemplate.nativeapptemplatefree.di.modules.DispatchersModule
 import com.nativeapptemplate.nativeapptemplatefree.network.Dispatcher
-import com.nativeapptemplate.nativeapptemplatefree.network.NatDispatchers
+import com.nativeapptemplate.nativeapptemplatefree.network.NativeAppTemplateDispatchers
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.components.SingletonComponent
@@ -33,11 +33,11 @@ import kotlinx.coroutines.test.TestDispatcher
 )
 internal object TestDispatchersModule {
   @Provides
-  @Dispatcher(NatDispatchers.IO)
+  @Dispatcher(NativeAppTemplateDispatchers.IO)
   fun providesIODispatcher(testDispatcher: TestDispatcher): CoroutineDispatcher = testDispatcher
 
   @Provides
-  @Dispatcher(NatDispatchers.Default)
+  @Dispatcher(NativeAppTemplateDispatchers.Default)
   fun providesDefaultDispatcher(
     testDispatcher: TestDispatcher,
   ): CoroutineDispatcher = testDispatcher

--- a/app/src/test/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/ShopBasicSettingsViewModelTest.kt
+++ b/app/src/test/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/ShopBasicSettingsViewModelTest.kt
@@ -2,7 +2,7 @@ package com.nativeapptemplate.nativeapptemplatefree.ui.shop_settings
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.testing.invoke
-import com.nativeapptemplate.nativeapptemplatefree.NatConstants
+import com.nativeapptemplate.nativeapptemplatefree.NativeAppTemplateConstants
 import com.nativeapptemplate.nativeapptemplatefree.model.Attributes
 import com.nativeapptemplate.nativeapptemplatefree.model.Data
 import com.nativeapptemplate.nativeapptemplatefree.model.Shop
@@ -120,7 +120,7 @@ class ShopBasicSettingsViewModelTest {
   @Test
   fun maximumNameLength_matchesConstant() = runTest {
     assertEquals(
-      NatConstants.MAXIMUM_SHOP_NAME_LENGTH,
+      NativeAppTemplateConstants.MAXIMUM_SHOP_NAME_LENGTH,
       viewModel.uiState.value.maximumNameLength,
     )
   }
@@ -128,7 +128,7 @@ class ShopBasicSettingsViewModelTest {
   @Test
   fun maximumDescriptionLength_matchesConstant() = runTest {
     assertEquals(
-      NatConstants.MAXIMUM_SHOP_DESCRIPTION_LENGTH,
+      NativeAppTemplateConstants.MAXIMUM_SHOP_DESCRIPTION_LENGTH,
       viewModel.uiState.value.maximumDescriptionLength,
     )
   }

--- a/app/src/test/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/item_tag_detail/ItemTagEditViewModelTest.kt
+++ b/app/src/test/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/item_tag_detail/ItemTagEditViewModelTest.kt
@@ -2,7 +2,7 @@ package com.nativeapptemplate.nativeapptemplatefree.ui.shop_settings.item_tag_de
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.testing.invoke
-import com.nativeapptemplate.nativeapptemplatefree.NatConstants
+import com.nativeapptemplate.nativeapptemplatefree.NativeAppTemplateConstants
 import com.nativeapptemplate.nativeapptemplatefree.model.Attributes
 import com.nativeapptemplate.nativeapptemplatefree.model.Data
 import com.nativeapptemplate.nativeapptemplatefree.model.ItemTag
@@ -56,7 +56,7 @@ class ItemTagEditViewModelTest {
 
   @Test
   fun maximumNameLength_matchesConstant() = runTest {
-    assertEquals(NatConstants.MAXIMUM_ITEM_TAG_NAME_LENGTH, viewModel.uiState.value.maximumNameLength)
+    assertEquals(NativeAppTemplateConstants.MAXIMUM_ITEM_TAG_NAME_LENGTH, viewModel.uiState.value.maximumNameLength)
   }
 
   @Test

--- a/app/src/test/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/item_tag_list/ItemTagCreateViewModelTest.kt
+++ b/app/src/test/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/item_tag_list/ItemTagCreateViewModelTest.kt
@@ -2,7 +2,7 @@ package com.nativeapptemplate.nativeapptemplatefree.ui.shop_settings.item_tag_li
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.testing.invoke
-import com.nativeapptemplate.nativeapptemplatefree.NatConstants
+import com.nativeapptemplate.nativeapptemplatefree.NativeAppTemplateConstants
 import com.nativeapptemplate.nativeapptemplatefree.model.Attributes
 import com.nativeapptemplate.nativeapptemplatefree.model.Data
 import com.nativeapptemplate.nativeapptemplatefree.model.ItemTag
@@ -51,7 +51,7 @@ class ItemTagCreateViewModelTest {
 
   @Test
   fun maximumNameLength_matchesConstant() = runTest {
-    assertEquals(NatConstants.MAXIMUM_ITEM_TAG_NAME_LENGTH, viewModel.uiState.value.maximumNameLength)
+    assertEquals(NativeAppTemplateConstants.MAXIMUM_ITEM_TAG_NAME_LENGTH, viewModel.uiState.value.maximumNameLength)
   }
 
   @Test
@@ -113,7 +113,7 @@ class ItemTagCreateViewModelTest {
   fun nameAtMaximumLength_isValid() = runTest {
     backgroundScope.launch(UnconfinedTestDispatcher()) { viewModel.uiState.collect() }
 
-    viewModel.updateName("A".repeat(NatConstants.MAXIMUM_ITEM_TAG_NAME_LENGTH))
+    viewModel.updateName("A".repeat(NativeAppTemplateConstants.MAXIMUM_ITEM_TAG_NAME_LENGTH))
 
     assertFalse(viewModel.hasInvalidDataName())
   }
@@ -122,7 +122,7 @@ class ItemTagCreateViewModelTest {
   fun nameAboveMaximumLength_isRejectedByUpdater() = runTest {
     backgroundScope.launch(UnconfinedTestDispatcher()) { viewModel.uiState.collect() }
 
-    viewModel.updateName("A".repeat(NatConstants.MAXIMUM_ITEM_TAG_NAME_LENGTH + 1))
+    viewModel.updateName("A".repeat(NativeAppTemplateConstants.MAXIMUM_ITEM_TAG_NAME_LENGTH + 1))
 
     // updater clamps; value should remain blank (initial)
     assertEquals("", viewModel.uiState.value.name)
@@ -132,7 +132,7 @@ class ItemTagCreateViewModelTest {
   fun descriptionAtMaximumLength_isValid() = runTest {
     backgroundScope.launch(UnconfinedTestDispatcher()) { viewModel.uiState.collect() }
 
-    viewModel.updateDescription("D".repeat(NatConstants.MAXIMUM_ITEM_TAG_DESCRIPTION_LENGTH))
+    viewModel.updateDescription("D".repeat(NativeAppTemplateConstants.MAXIMUM_ITEM_TAG_DESCRIPTION_LENGTH))
 
     assertFalse(viewModel.hasInvalidDataDescription())
   }
@@ -141,7 +141,7 @@ class ItemTagCreateViewModelTest {
   fun descriptionAboveMaximumLength_isRejectedByUpdater() = runTest {
     backgroundScope.launch(UnconfinedTestDispatcher()) { viewModel.uiState.collect() }
 
-    viewModel.updateDescription("D".repeat(NatConstants.MAXIMUM_ITEM_TAG_DESCRIPTION_LENGTH + 1))
+    viewModel.updateDescription("D".repeat(NativeAppTemplateConstants.MAXIMUM_ITEM_TAG_DESCRIPTION_LENGTH + 1))
 
     assertEquals("", viewModel.uiState.value.description)
   }

--- a/app/src/test/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shops/ShopCreateViewModelTest.kt
+++ b/app/src/test/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shops/ShopCreateViewModelTest.kt
@@ -1,6 +1,6 @@
 package com.nativeapptemplate.nativeapptemplatefree.ui.shops
 
-import com.nativeapptemplate.nativeapptemplatefree.NatConstants
+import com.nativeapptemplate.nativeapptemplatefree.NativeAppTemplateConstants
 import com.nativeapptemplate.nativeapptemplatefree.model.Attributes
 import com.nativeapptemplate.nativeapptemplatefree.model.Data
 import com.nativeapptemplate.nativeapptemplatefree.model.Shop
@@ -84,13 +84,13 @@ class ShopCreateViewModelTest {
 
   @Test
   fun maximumNameLength_matchesConstant() = runTest {
-    assertEquals(NatConstants.MAXIMUM_SHOP_NAME_LENGTH, viewModel.uiState.value.maximumNameLength)
+    assertEquals(NativeAppTemplateConstants.MAXIMUM_SHOP_NAME_LENGTH, viewModel.uiState.value.maximumNameLength)
   }
 
   @Test
   fun maximumDescriptionLength_matchesConstant() = runTest {
     assertEquals(
-      NatConstants.MAXIMUM_SHOP_DESCRIPTION_LENGTH,
+      NativeAppTemplateConstants.MAXIMUM_SHOP_DESCRIPTION_LENGTH,
       viewModel.uiState.value.maximumDescriptionLength,
     )
   }

--- a/datastore-proto/src/main/proto/user_preferences.proto
+++ b/datastore-proto/src/main/proto/user_preferences.proto
@@ -29,7 +29,7 @@ message UserPreferences {
   int32 android_app_version = 20;
   bool should_update_privacy = 21;
   bool should_update_terms = 22;
-  reserved 23; // was maximum_name_length, now in NatConstants
+  reserved 23; // was maximum_name_length, now in NativeAppTemplateConstants
   int32 shop_limit_count = 28;
 
   bool is_email_updated = 32;


### PR DESCRIPTION
## Summary
- Rename all `Nat`-prefixed Kotlin symbols to `NativeAppTemplate*` (`NatApp`, `NatAppState`, `NatConstants`, `NatPreferencesDataSource`, `NatNavHost`, `NatAlertDialog`, `NatBackground`, `NatBottomBar`, `NatDispatchers`, `NatNavigationBar*`, `NatOkHttpClient`, `NatPreferences`, `NatTheme`, `NatTypography`, plus `rememberNatAppState`) and rename the 8 corresponding source files.
- Rename Compose theme styles `Theme.Nat` and `Theme.Nat.Splash` (and the `NightAdjusted.Theme.Nat` parent) to the `Theme.NativeAppTemplate.*` family in `themes.xml`, `values-night/themes.xml`, and `AndroidManifest.xml`.
- Rename the three Gradle properties `NATEMPLATE_API_{DOMAIN,PORT,SCHEME}` to `NATIVEAPPTEMPLATE_API_*` in `app/build.gradle.kts`, `README.md`, and `CLAUDE.md`.
- Rename the `NATA-XXXX` error-code prefix to `NATIVEAPPTEMPLATE-XXXX` across `ApiException.kt`, `AppError.kt`, `CodedErrorTest.kt`, `CLAUDE.md`, and `CHANGELOG.md`.

Goal: every reference to the product uses one canonical stem (`NativeAppTemplate`) so the upstream substrate renamer's `NativeAppTemplate -> <slug-pascal>` rename pair handles every occurrence in one rule. After this PR, `rg "Nat[A-Z]|NATEMPLATE|NATA-"` returns zero matches outside `.git/` and `docs-private/`.

Mirrors upstream PR nativeapptemplate/NativeAppTemplate-Android#58 for this Free fork.

## Test plan
- [x] `./gradlew assembleDebug` — green
- [x] `./gradlew testDebugUnitTest` — green
- [x] `rg "Nat[A-Z]|NATEMPLATE|NATA-"` returns no matches outside `.git/` / `docs-private/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)