### PR TITLE
Clarify Shop list card tag labels as item tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [3.2.1] - 2026-05-02
+
+### Changed
+- Shop list card stat labels now read "completed item tags" / "all item tags" to align with the Number Tag → Item Tag terminology
+
 ## [3.2.0] - 2026-05-02
 
 ### Added

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,8 +14,8 @@ android {
     applicationId = "com.nativeapptemplate.nativeapptemplatefree"
     targetSdk = 36
     minSdk = 26
-    versionCode = 5
-    versionName = "3.2.0"
+    versionCode = 6
+    versionName = "3.2.1"
 
     vectorDrawables {
       useSupportLibrary = true

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shops/ShopListCardView.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shops/ShopListCardView.kt
@@ -47,8 +47,8 @@ fun ShopListCardView(
           modifier = Modifier
             .padding(top = 16.dp),
         ) {
-          CountRow(icon = Icons.Outlined.Flag, count = data.getCompletedItemTagsCount(), countLabel = "completed tags")
-          CountRow(icon = Icons.Outlined.Rectangle, count = data.getItemTagsCount(), countLabel = "all tags")
+          CountRow(icon = Icons.Outlined.Flag, count = data.getCompletedItemTagsCount(), countLabel = "completed item tags")
+          CountRow(icon = Icons.Outlined.Rectangle, count = data.getItemTagsCount(), countLabel = "all item tags")
         }
 
         Text(


### PR DESCRIPTION
## Summary
- Rename Shop list card stat labels from "completed tags" / "all tags" to "completed item tags" / "all item tags"
- Aligns visible labels with the Number Tag → Item Tag terminology rename
- Mirrors [NativeAppTemplate-Android#59](https://github.com/nativeapptemplate/NativeAppTemplate-Android/pull/59) and [NativeAppTemplate-iOS#72](https://github.com/nativeapptemplate/NativeAppTemplate-iOS/pull/72)

## Test plan
- [ ] Open the Shop list and confirm each card shows "completed item tags" and "all item tags" beside the counts
- [x] `./gradlew test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)