### PR TITLE
Fix invisible sparkle on welcome and sign-up screens in light mode

### DIFF
--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/app_root/OnboardingView.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/app_root/OnboardingView.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -38,8 +39,11 @@ import com.nativeapptemplate.nativeapptemplatefree.ui.common.NonScaledSp.nonScal
 internal fun OnboardingView(
   onStartClick: () -> Unit,
 ) {
+  val brandNavy = colorResource(R.color.ic_launcher_background)
+
   Scaffold(
-    topBar = { TopAppBar(onStartClick) },
+    topBar = { TopAppBar(onStartClick, brandNavy) },
+    containerColor = brandNavy,
     modifier = Modifier.fillMaxSize(),
   ) { padding ->
     Column(
@@ -60,7 +64,7 @@ internal fun OnboardingView(
       Spacer(Modifier.height(24.dp))
       Text(
         text = stringResource(R.string.welcome_to_app, stringResource(R.string.app_name)),
-        color = MaterialTheme.colorScheme.onBackground,
+        color = Color.White,
         fontSize = 34.sp.nonScaledSp,
         lineHeight = 41.sp.nonScaledSp,
         fontWeight = FontWeight.Bold,
@@ -76,13 +80,16 @@ internal fun OnboardingView(
 @Composable
 private fun TopAppBar(
   onStartClick: () -> Unit,
+  containerColor: Color,
 ) {
   val context = LocalContext.current
 
   CenterAlignedTopAppBar(
     colors = TopAppBarDefaults.topAppBarColors(
-      containerColor = MaterialTheme.colorScheme.primaryContainer,
-      titleContentColor = MaterialTheme.colorScheme.primary,
+      containerColor = containerColor,
+      titleContentColor = Color.White,
+      navigationIconContentColor = Color.White,
+      actionIconContentColor = Color.White,
     ),
     title = { Text("") },
     actions = {
@@ -91,6 +98,7 @@ private fun TopAppBar(
       ) {
         Text(
           "Start",
+          color = Color.White,
           style = MaterialTheme.typography.displaySmall,
         )
       }
@@ -101,6 +109,7 @@ private fun TopAppBar(
       ) {
         Text(
           stringResource(R.string.support_website),
+          color = Color.White,
         )
       }
     },

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/app_root/SignUpOrSignInView.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/app_root/SignUpOrSignInView.kt
@@ -25,7 +25,6 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.LinkAnnotation
@@ -76,7 +75,7 @@ internal fun SignUpOrSignInView(
       Icon(
         imageVector = Icons.Filled.AutoAwesome,
         contentDescription = null,
-        tint = Color.White,
+        tint = MaterialTheme.colorScheme.primary,
         modifier = Modifier
           .fillMaxWidth()
           .height(256.dp)


### PR DESCRIPTION
## Summary
In light display mode the welcome screen rendered the white sparkle on a near-white themed background — the sparkle disappeared and the screen looked empty. Pin the welcome screen to the brand navy `#1A2332` (same as the launcher icon background and splash) regardless of theme, so the white sparkle and title always have contrast. This also extends the launcher/splash visual identity into the first screen the user sees.

The sign-up/sign-in screen stays theme-following (it has chrome — buttons, terms link — that should match the rest of the app), so its sparkle tint moves from hard-coded `Color.White` to `MaterialTheme.colorScheme.primary` to keep contrast in both modes.

Mirrors [NativeAppTemplate-Android#65](https://github.com/nativeapptemplate/NativeAppTemplate-Android/pull/65).

## Test plan
- [x] `./gradlew :app:assembleDebug` succeeds
- [x] `./gradlew spotlessKotlinCheck` passes
- [ ] Light mode: welcome screen shows white sparkle + title on navy; sign-up screen shows primary-tinted sparkle on light background
- [ ] Dark mode: welcome screen unchanged (already navy + white); sign-up screen shows primary-tinted sparkle on dark background

🤖 Generated with [Claude Code](https://claude.com/claude-code)