### PR TITLE
Drop articles before renameable domain words

### DIFF
--- a/app/src/main/assets/shop.json
+++ b/app/src/main/assets/shop.json
@@ -4,7 +4,7 @@
     "type": "shop",
     "attributes": {
       "name": "Shop1",
-      "description": "This is a Shop1",
+      "description": "This is Shop1",
       "time_zone": "Tokyo"
     },
     "meta": {

--- a/app/src/main/assets/shops.json
+++ b/app/src/main/assets/shops.json
@@ -5,7 +5,7 @@
       "type": "shop",
       "attributes": {
         "name": "Shop1",
-        "description": "This is a Shop1",
+        "description": "This is Shop1",
         "time_zone": "Tokyo"
       },
       "meta": {
@@ -18,7 +18,7 @@
       "type": "shop",
       "attributes": {
         "name": "Shop2",
-        "description": "This is a Shop2",
+        "description": "This is Shop2",
         "time_zone": "Tokyo"
       },
       "meta": {
@@ -31,7 +31,7 @@
       "type": "shop",
       "attributes": {
         "name": "Shop3",
-        "description": "This is a Shop3",
+        "description": "This is Shop3",
         "time_zone": "Tokyo"
       },
       "meta": {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -78,13 +78,13 @@
   <string name="shop_name_help">Name must be 1-%1$d characters.</string>
   <string name="shop_description_help">Description must be 0-%1$d characters.</string>
   <string name="add_shop_description">Add a new shop.</string>
-  <string name="tap_shop_below">Tap a shop below</string>
+  <string name="tap_shop_below">Tap shop below</string>
 
   <!-- Shop Detail Screen -->
   <string name="message_shop_created">Shop added.</string>
   <string name="message_shop_deleted">Shop removed.</string>
   <string name="message_shop_updated">Shop updated.</string>
-  <string name="shop_detail_instruction">Swipe an item tag to change its status.</string>
+  <string name="shop_detail_instruction">Swipe to change item tag status.</string>
   <string name="complete">Complete</string>
   <string name="idle">Idle</string>
 
@@ -101,7 +101,7 @@
   <string name="completed_at_label">Completed at</string>
   <string name="item_tag_name_placeholder">Buy milk</string>
   <string name="label_add_item_tag">Add Item Tag</string>
-  <string name="add_item_tag_description">Add a new item tag and start changing the item tag status.</string>
+  <string name="add_item_tag_description">Add a new item tag and start changing item tag status.</string>
   <string name="item_tag_name_is_invalid">Item tag name is invalid.</string>
   <string name="item_tag_description_is_invalid">Item tag description is invalid.</string>
   <string name="item_tag_name_help">Name must be 1-%1$d characters.</string>

--- a/app/src/test/kotlin/com/nativeapptemplate/nativeapptemplatefree/demo/shop/DemoShopRepositoryTest.kt
+++ b/app/src/test/kotlin/com/nativeapptemplate/nativeapptemplatefree/demo/shop/DemoShopRepositoryTest.kt
@@ -28,7 +28,7 @@ class DemoShopRepositoryTest {
     type = "shop",
     attributes = Attributes(
       name = "Shop1",
-      description = "This is a Shop1",
+      description = "This is Shop1",
       timeZone = "Tokyo",
     ),
     meta = Meta(
@@ -70,7 +70,7 @@ class DemoShopRepositoryTest {
         ShopBody(
           shopBodyDetail = ShopBodyDetail(
             name = "Shop1",
-            description = "This is a Shop1",
+            description = "This is Shop1",
             timeZone = "Tokyo",
           ),
         ),
@@ -87,7 +87,7 @@ class DemoShopRepositoryTest {
         shopUpdateBody = ShopUpdateBody(
           shopUpdateBodyDetail = ShopUpdateBodyDetail(
             name = "Shop1",
-            description = "This is a Shop1",
+            description = "This is Shop1",
             timeZone = "Tokyo",
           ),
         ),


### PR DESCRIPTION
## Summary
- Apply [`SUBSTRATE-CONTRACT.md`](https://github.com/nativeapptemplate/nativeapptemplate-agent/blob/main/docs/SUBSTRATE-CONTRACT.md) rule 1: UI strings must not couple articles to renameable domain nouns (`Shop`, `ItemTag`, `Shopkeeper`), so the agent's rename pipeline produces grammatical output for any target word (e.g. `"Swipe an item tag…"` → `"Swipe an patient…"` after `ItemTag → Patient`).
- Mirrors [nativeapptemplate/NativeAppTemplate-iOS#77](https://github.com/nativeapptemplate/NativeAppTemplate-iOS/pull/77). Of the 7 iOS UI string changes, **3 have Android equivalents** in `app/src/main/res/values/strings.xml`; the other 4 are toast/error strings (`shopDeletedError`, `itemTagDeletedError`, `itemTagCompletedError`, `itemTagIdledError`) that don't exist on Android, so they're skipped.
- The 1 iOS test-fixture change (`ShopAdapterTest.swift`) maps to the seed JSON in `app/src/main/assets/{shop,shops}.json` plus the matching `DemoShopRepositoryTest` assertions — all four `"This is a Shop1"`-style strings updated to `"This is Shop1"` so demo deserialization tests stay green.
- One change matches the contract's "Also good" example verbatim: `shop_detail_instruction` becomes `"Swipe to change item tag status."`

## Test plan
- [x] `./gradlew testDebugUnitTest --tests "com.nativeapptemplate.nativeapptemplatefree.demo.shop.DemoShopRepositoryTest"` — passes
- [x] `./gradlew spotlessCheck lintDebug` — clean
- [ ] Spot-check the affected UI strings render correctly: shop list empty state ("Tap shop below"), item-tag list empty state ("Add a new item tag and start changing item tag status."), shop detail instruction ("Swipe to change item tag status.")

🤖 Generated with [Claude Code](https://claude.com/claude-code)