### PR TITLE
Bump versionCode to 10 and versionName to 3.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [3.2.5] - 2026-05-08
+
+### Changed
+- Dropped articles before renameable domain nouns in UI strings ("Tap shop below", "Swipe to change item tag status.", "Add a new item tag and start changing item tag status.") and seed-data fixtures so the cross-platform rename pipeline produces grammatical output for any target word — mirrors [iOS PR #77](https://github.com/nativeapptemplate/NativeAppTemplate-iOS/pull/77)
+
 ## [3.2.4] - 2026-05-04
 
 ### Fixed

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,8 +14,8 @@ android {
     applicationId = "com.nativeapptemplate.nativeapptemplatefree"
     targetSdk = 36
     minSdk = 26
-    versionCode = 9
-    versionName = "3.2.4"
+    versionCode = 10
+    versionName = "3.2.5"
 
     vectorDrawables {
       useSupportLibrary = true


### PR DESCRIPTION
## Summary
- Bump `versionCode` 9 → 10, `versionName` 3.2.4 → 3.2.5
- Add 3.2.5 changelog entry covering the rename-safety contract fix from #51

## Test plan
- [x] `app/build.gradle.kts` reflects new code/name
- [x] `CHANGELOG.md` 3.2.5 section added in Keep-a-Changelog format

🤖 Generated with [Claude Code](https://claude.com/claude-code)