### PR TITLE
ItemTag state UI: rename Idling → Idled across the board

### DIFF
--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/common/tags/IdledTag.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/common/tags/IdledTag.kt
@@ -6,9 +6,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import com.nativeapptemplate.nativeapptemplatefree.designsystem.theme.NativeAppTemplateTheme
 
 @Composable
-fun IdlingTag() {
+fun IdledTag() {
   TagView(
-    text = "IDLING",
+    text = "IDLED",
     textColor = MaterialTheme.colorScheme.onSurfaceVariant,
     backgroundColor = MaterialTheme.colorScheme.surfaceVariant,
   )
@@ -16,8 +16,8 @@ fun IdlingTag() {
 
 @Preview
 @Composable
-private fun IdlingTagPreview() {
+private fun IdledTagPreview() {
   NativeAppTemplateTheme {
-    IdlingTag()
+    IdledTag()
   }
 }

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_detail/ShopDetailCardView.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_detail/ShopDetailCardView.kt
@@ -13,7 +13,7 @@ import androidx.compose.ui.unit.dp
 import com.nativeapptemplate.nativeapptemplatefree.model.Data
 import com.nativeapptemplate.nativeapptemplatefree.model.ItemTagState
 import com.nativeapptemplate.nativeapptemplatefree.ui.common.tags.CompletedTag
-import com.nativeapptemplate.nativeapptemplatefree.ui.common.tags.IdlingTag
+import com.nativeapptemplate.nativeapptemplatefree.ui.common.tags.IdledTag
 import com.nativeapptemplate.nativeapptemplatefree.utils.DateUtility.cardDateTimeString
 
 @Composable
@@ -54,7 +54,7 @@ fun ShopDetailCardView(
             )
           }
           else -> {
-            IdlingTag()
+            IdledTag()
           }
         }
       }

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/item_tag_detail/ItemTagDetailView.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/item_tag_detail/ItemTagDetailView.kt
@@ -46,7 +46,7 @@ import com.nativeapptemplate.nativeapptemplatefree.ui.common.MainButtonView
 import com.nativeapptemplate.nativeapptemplatefree.ui.common.NativeAppTemplateAlertDialog
 import com.nativeapptemplate.nativeapptemplatefree.ui.common.SnackbarMessageEffect
 import com.nativeapptemplate.nativeapptemplatefree.ui.common.tags.CompletedTag
-import com.nativeapptemplate.nativeapptemplatefree.ui.common.tags.IdlingTag
+import com.nativeapptemplate.nativeapptemplatefree.ui.common.tags.IdledTag
 import com.nativeapptemplate.nativeapptemplatefree.utils.DateUtility.cardDateTimeString
 
 @Composable
@@ -194,7 +194,7 @@ private fun HeaderRow(itemTag: ItemTag) {
 
     when (itemTag.getData()?.getItemTagState()) {
       ItemTagState.Completed -> CompletedTag()
-      ItemTagState.Idled -> IdlingTag()
+      ItemTagState.Idled -> IdledTag()
       null -> Unit
     }
   }

--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/item_tag_list/ItemTagListCardView.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/item_tag_list/ItemTagListCardView.kt
@@ -16,7 +16,7 @@ import androidx.compose.ui.unit.dp
 import com.nativeapptemplate.nativeapptemplatefree.model.Data
 import com.nativeapptemplate.nativeapptemplatefree.model.ItemTagState
 import com.nativeapptemplate.nativeapptemplatefree.ui.common.tags.CompletedTag
-import com.nativeapptemplate.nativeapptemplatefree.ui.common.tags.IdlingTag
+import com.nativeapptemplate.nativeapptemplatefree.ui.common.tags.IdledTag
 import com.nativeapptemplate.nativeapptemplatefree.utils.DateUtility.cardDateTimeString
 
 @Composable
@@ -69,7 +69,7 @@ fun ItemTagListCardView(
             )
           }
         }
-        ItemTagState.Idled -> IdlingTag()
+        ItemTagState.Idled -> IdledTag()
         null -> Unit
       }
     }

--- a/model/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/model/ItemTagState.kt
+++ b/model/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/model/ItemTagState.kt
@@ -1,7 +1,7 @@
 package com.nativeapptemplate.nativeapptemplatefree.model
 
 enum class ItemTagState(val param: String, val title: String) {
-  Idled("idled", "Idling"),
+  Idled("idled", "Idled"),
 
   Completed("completed", "Completed"),
   ;


### PR DESCRIPTION
## Summary
Aligns the user-visible "Idling" string with the underlying enum case `Idled` and the `Idled` ↔ `Completed` parallel-tense pair (already used for the Completed display string). Eliminates the tense mismatch where the state badge read `"IDLING"` while its enum was `Idled` and its sibling state was `"COMPLETED"`.

## Changes
- `ItemTagState.Idled.title` returns `"Idled"` (was `"Idling"`)
- `IdlingTag` composable renamed to `IdledTag` — file (`IdlingTag.kt` → `IdledTag.kt`), function, and `@Preview` function
- `TagView` text literal `"IDLING"` → `"IDLED"` (uppercase chip text, matching the existing convention used by `CompletedTag`)
- Three call sites updated (`ItemTagListCardView`, `ItemTagDetailView`, `ShopDetailCardView`): import + composable invocation

The test method name `stateIsLoading_whenIdlingItemTag_becomesFalse` is intentionally left as-is — it's a verb form ("the action of idling an ItemTag") referring to the operation, not the state label.

Companion PRs land the same change in `NativeAppTemplate-Free-iOS` (#68), `NativeAppTemplate-iOS` (paid), and `NativeAppTemplate-Android` (paid) so all four substrate editions stay UI-consistent.

## Test plan
- [ ] `./gradlew assembleDebug` succeeds
- [ ] State badge on the ItemTag list/detail screens reads "IDLED" before completion and "COMPLETED" after
- [ ] Idled → Completed state transition still works ("Mark as completed" button)

🤖 Generated with [Claude Code](https://claude.com/claude-code)