### PR TITLE
Fix description silently dropped by encodeDefaults=false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [3.2.6] - 2026-05-24
+
+### Fixed
+- Clearing an item tag's description on edit was silently ignored — the Retrofit JSON config keeps `encodeDefaults = false`, so `ItemTagBodyDetail.description = ""` (equal to its declared default) was dropped from the request body and the server's partial update left the old description in place. Removed the default so the empty string is always sent
+
 ## [3.2.5] - 2026-05-08
 
 ### Changed

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,8 +14,8 @@ android {
     applicationId = "com.nativeapptemplate.nativeapptemplatefree"
     targetSdk = 36
     minSdk = 26
-    versionCode = 10
-    versionName = "3.2.5"
+    versionCode = 11
+    versionName = "3.2.6"
 
     vectorDrawables {
       useSupportLibrary = true

--- a/app/src/test/kotlin/com/nativeapptemplate/nativeapptemplatefree/demo/item_tag/DemoItemTagRepositoryTest.kt
+++ b/app/src/test/kotlin/com/nativeapptemplate/nativeapptemplatefree/demo/item_tag/DemoItemTagRepositoryTest.kt
@@ -71,6 +71,7 @@ class DemoItemTagRepositoryTest {
         ItemTagBody(
           itemTagBodyDetail = ItemTagBodyDetail(
             name = itemTagData.getName(),
+            description = "",
           ),
         ),
       ).first(),
@@ -86,6 +87,7 @@ class DemoItemTagRepositoryTest {
         itemTagBody = ItemTagBody(
           itemTagBodyDetail = ItemTagBodyDetail(
             name = itemTagData.getName(),
+            description = "",
           ),
         ),
       ).first(),

--- a/model/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/model/ItemTagBodyDetail.kt
+++ b/model/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/model/ItemTagBodyDetail.kt
@@ -8,5 +8,9 @@ import kotlinx.serialization.Serializable
 @Parcelize
 data class ItemTagBodyDetail(
   val name: String,
-  val description: String = "",
+  // No default: with the Json config's encodeDefaults = false, a value equal to
+  // its default ("") is dropped from the payload, so clearing a description on
+  // edit would be silently ignored by the server's partial update. Both call
+  // sites supply description explicitly.
+  val description: String,
 ) : Parcelable


### PR DESCRIPTION
## Summary

Mirrors [NativeAppTemplate-Android a78f42e](https://github.com/nativeapptemplate/NativeAppTemplate-Android/commit/a78f42ed767e82606cfc33cac13f09324f534431).

The Retrofit kotlinx `Json` config (`NetModule`) keeps `encodeDefaults = false`, so a `@Serializable` request-body property equal to its declared default is omitted from the payload.

`ItemTagBodyDetail.description = ""` (== default) was dropped, so **clearing a description on edit was silently ignored** by the server's partial update. This drops the default — both production call sites (`ItemTagCreateViewModel`, `ItemTagEditViewModel`) already pass `description` explicitly, so the empty string is now always sent.

> Note: the upstream commit also fixes `DeviceRegistrationBody.platform`. That part does not apply here — the Free variant has no device registration.

## Changes
- `ItemTagBodyDetail`: removed the `description` default (with explanatory comment)
- `DemoItemTagRepositoryTest`: pass `description = ""` explicitly at both call sites
- Bumped versionCode 10 → 11, versionName 3.2.5 → 3.2.6
- Updated CHANGELOG

## Testing
- `./gradlew :app:testDebugUnitTest --tests "...DemoItemTagRepositoryTest"` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)