### PR TITLE
docs(readme): list Push Notifications (FCM) as a paid-only feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ The full versions ([NativeAppTemplate-Android (Solo)](https://nativeapptemplate.
 - User Invitation to Organizations
 - Role-Based Permissions and Access Control
 - Organization Switching UI
+- Push Notifications via FCM
 
 ## Getting Started
 


### PR DESCRIPTION
## What

Adds `Push Notifications via FCM` to the **Not Included in the Free Version** list in the README.

## Why

The paid Android README already lists push as a free-version exclusion, but this repo's exclusion list omitted it — an inconsistency between the two editions' docs.

Verified the free app ships **no** push code: no `push/` directory, no FCM/FirebaseMessaging/remote-notification references anywhere in the source. So push is genuinely paid-only, and the README now reflects the actual feature boundary.

## Scope

Documentation only — one line added. No code changes.