### PR TITLE
docs: remove NFC tag operations (moved to v1-with-nfc branch)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-NativeAppTemplate-Free-Android is a native Android app (100% Kotlin, 100% Jetpack Compose) for managing walk-in customer waitlists using NFC tags and QR codes. It connects to a Rails backend API at `api.nativeapptemplate.com`. Inspired by [nowinandroid](https://github.com/android/nowinandroid).
+NativeAppTemplate-Free-Android is a native Android app (100% Kotlin, 100% Jetpack Compose) for managing walk-in customer waitlists. It connects to a Rails backend API at `api.nativeapptemplate.com`. Inspired by [nowinandroid](https://github.com/android/nowinandroid).
 
 ## Build & Run Commands
 
@@ -39,14 +39,14 @@ MVVM layered architecture following [Android Modern App Architecture](https://de
 - **Network Layer** (`network/`): `AuthInterceptor` for token injection, `RequestHelper` for request construction.
 - **DI** (`di/modules/`): Hilt modules — `NetModule` (Retrofit/OkHttp), `DataModule` (repository bindings), `DataStoreModule`, `DispatchersModule`, `CoroutineScopesModule`.
 - **DataStore** (`datastore/`): Proto DataStore for user preferences. Proto definitions live in `app/src/main/proto/`.
-- **Navigation**: `NativeAppTemplateNavHost.kt` is the top-level nav graph. Three bottom-nav sections: Shops, Scan, Settings. Each section uses nested navigation graphs via `*BaseRoute`.
+- **Navigation**: `NativeAppTemplateNavHost.kt` is the top-level nav graph. Two bottom-nav sections: Shops, Settings. Each section uses nested navigation graphs via `*BaseRoute`.
 
 ## Key Patterns
 
 - **API response handling**: Uses [Sandwich](https://github.com/skydoves/sandwich) library (`ApiResponse` type) for Retrofit call adaptation.
 - **Dependency injection**: Hilt with `@InstallIn(SingletonComponent::class)`. Repositories are bound via `@Binds` in `DataModule`.
 - **Navigation routes**: Defined as extension functions on `NavGraphBuilder` (e.g., `shopListView()`, `navigateToShopDetail()`). Routes use type-safe navigation.
-- **Proto DataStore**: User preferences and NFC scan state are persisted via Protocol Buffers (lite).
+- **Proto DataStore**: User preferences are persisted via Protocol Buffers (lite).
 
 ## Error Handling (CodedError System)
 All errors should use the `CodedError` interface. Error codes use the `NATIVEAPPTEMPLATE-XXXX` prefix (NativeAppTemplate Android).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NativeAppTemplate-Free-Android
 
-NativeAppTemplate-Free-Android is a modern, comprehensive, and production-ready native Android app with user authentication and [background tag reading](https://developer.android.com/develop/connectivity/nfc/nfc).  
+NativeAppTemplate-Free-Android is a modern, comprehensive, and production-ready native Android app with user authentication and a full CRUD example.  
 This Android app is a free version of  [NativeAppTemplate-Android (Solo)](https://nativeapptemplate.com/products/android-solo) and [NativeAppTemplate-Android (Team)](https://nativeapptemplate.com/products/android-team).  
 
 The iOS version is available here: [NativeAppTemplate-Free-iOS](https://github.com/nativeapptemplate/NativeAppTemplate-Free-iOS).  
@@ -45,52 +45,7 @@ NativeAppTemplate-Free-Android uses modern Android development tools and practic
 
 ## NFC Tag Operations
 
-<details>
-<summary><strong>How NFC tag writing and background reading works</strong></summary>
-
-### Overview  
-
-![Screenshot showing Overview before](https://github.com/nativeapptemplate/NativeAppTemplate-Free-Android/blob/main/docs/images/overview_before.png "Screenshot showing Overview before")
-
-![Screenshot showing Overview after](https://github.com/nativeapptemplate/NativeAppTemplate-Free-Android/blob/main/docs/images/overview_after.png "Screenshot showing Overview after")
-
-The app replaces traditional paper tags with NFC tags to efficiently manage walk-in customer waitlists. It writes application-specific information onto your NFC cards (referred to as :red_circle: **Server Tag** and :large_blue_circle: **Customer Tag**).
-
-**For Customers:**  
-When a customer scans a :large_blue_circle: **Customer Tag**, they can view the :green_circle: **Number Tags Webpage** (a public webpage) on their mobile browser. This page displays completed Number Tags.
-
-**For Staff:**  
-By scanning a :red_circle: **Server Tag** paired with the :large_blue_circle: **Customer Tag**, staff can complete a Number Tag. Completed Number Tags automatically appear on the :green_circle: **Number Tags Webpage** for customer reference.
-
-### How It Works  
-
-![Screenshot showing Write Application Info to Tag screen, Scan Tag screen, and Shop Detail screen](https://github.com/nativeapptemplate/NativeAppTemplate-Free-Android/blob/main/docs/images/screenshots_nfc.png "Screenshot showing Write Application Info to Tag screen, Scan Tag screen, and Shop Detail screen")
-
-1. Write application info to pair **Number Tags** (Server Tag and Customer Tag) or a **Customer QR code**:  
-   - Go to: **Shops > [Shop] > Shop Settings > Manage Number Tags > [Number Tag]**.  
-2. Scan a **Server Tag** in the **Scan** tab.  
-3. View the updated **Number Tags** status in the **Shop Detail** screen or on the **Number Tags Webpage** (see Background Tag Reading GIF below).  
-
-### Recommended NFC Tags  
-For best performance, use **NTAG215 (540 bytes)** tags.  
-Example: [50pcs NFC Cards Ntag215](https://www.amazon.com/dp/B087FRYY8S) (Amazon USA).  
-
----
-
-### Background Tag Reading  
-
-![Gif showing Background Tag Reading](https://github.com/nativeapptemplate/NativeAppTemplate-Free-Android/blob/main/docs/images/nfc.gif "Showing Background Tag Reading")  
-
-1. Scan a Server Tag.  
-2. View the updated Number Tags status in the **Shop Detail** screen or on the **Number Tags Webpage**.  
-
-The **Number Tags Webpage** updates in real-time using Rails [Turbo](https://turbo.hotwired.dev).  
-This functionality is part of the open-source [nativeapptemplateapi](https://github.com/nativeapptemplate/nativeapptemplateapi) backend.  
-
-> **Note:**  
-> The GIF above shows [MyTurnTag Creator for iOS](https://apps.apple.com/app/myturntag-creator/id1516198303) in action, which may behave slightly differently from **NativeAppTemplate-Free-Android**.
-
-</details>
+NFC tag writing and background tag reading were part of v1 and have been removed from the current version. The full NFC implementation remains available in the [`v1-with-nfc`](https://github.com/nativeapptemplate/NativeAppTemplate-Free-Android/tree/v1-with-nfc) branch.
 
 ## Not Included in the Free Version
 
@@ -137,7 +92,6 @@ Cleartext HTTP to private IPs is already permitted in debug via `app/src/debug/r
 ## Blog
 
 - [Key Differences in MVVM Architecture: iOS vs. Android](https://medium.com/@dadachix/key-differences-in-mvvm-architecture-ios-vs-android-e239d30b2ea7)
-- [Cross-Platform Background NFC Tag Reading](https://medium.com/@dadachix/cross-platform-background-nfc-tag-reading-8a704f0cb6e9)
 
 ## Contributing
 


### PR DESCRIPTION
## What

The NFC code has been removed from `main` and preserved in the [`v1-with-nfc`](https://github.com/nativeapptemplate/NativeAppTemplate-Free-Android/tree/v1-with-nfc) branch. This drops the now-stale NFC documentation:

- **README.md**
  - Replaced the entire "## NFC Tag Operations" section with a short pointer to the `v1-with-nfc` branch
  - Dropped "background tag reading" from the intro tagline (→ "a full CRUD example")
  - Removed the "Cross-Platform Background NFC Tag Reading" blog link
- **CLAUDE.md**
  - Fixed the project description, the "Scan" bottom-nav entry (→ Shops, Settings), and the "NFC scan state" DataStore note

## Why

Verified NFC is fully gone from source (no `NfcAdapter`/`Scan`/QR tokens in Kotlin, no NFC proto). The Scan tab and QR were removed in the same change as NFC, so those stale mentions are corrected too. Paid READMEs were already cleaned; CHANGELOGs and API planning docs intentionally record the removal and are left untouched.

## Scope

Documentation only. Orphaned NFC images remain under `docs/images/` — harmless; can be pruned separately if desired.