### PR TITLE
Fix Add-ItemTag FAB accessibility label

### DIFF
--- a/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/item_tag_list/ItemTagListView.kt
+++ b/app/src/main/kotlin/com/nativeapptemplate/nativeapptemplatefree/ui/shop_settings/item_tag_list/ItemTagListView.kt
@@ -163,7 +163,7 @@ private fun ItemTagListContentView(
           onAddItemTagClick(viewModel.shopId)
         },
       ) {
-        Icon(Icons.Filled.Add, stringResource(id = R.string.add_shop))
+        Icon(Icons.Filled.Add, stringResource(id = R.string.label_add_item_tag))
       }
     },
     modifier = Modifier.fillMaxSize(),


### PR DESCRIPTION
The floating action button in `ItemTagListView` whose `onClick` is `onAddItemTagClick(...)` used `R.string.add_shop` ("Add Shop") as its `contentDescription`, so screen readers announced the wrong action. The visible title/form already say "Add Item Tag"; only the accessibility label was wrong (surfaced in the element tree, not visually). Swapped to the existing `R.string.label_add_item_tag` ("Add Item Tag").

The Shops list FAB (`ShopListView`) keeps `add_shop` — correct there, since it adds a shop.

Cosmetic/a11y only; no behavior change. Companion to the paid edition's PR in NativeAppTemplate-Android.

🤖 Generated with [Claude Code](https://claude.com/claude-code)