### PR TITLE
docs: link to nativeapptemplate-agent (generate a customized app from a spec)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ This Android app is a free version of  [NativeAppTemplate-Android (Solo)](https:
 
 The iOS version is available here: [NativeAppTemplate-Free-iOS](https://github.com/nativeapptemplate/NativeAppTemplate-Free-iOS).  
 
+Want this template adapted to your own domain? [nativeapptemplate-agent](https://github.com/nativeapptemplate/nativeapptemplate-agent) is a Claude Code agent that turns a one-sentence spec (e.g. *"a walk-in queue for a barbershop"*) into a coherent three-platform app — this Jetpack Compose Android app, a matching [Rails 8.1 API](https://github.com/nativeapptemplate/nativeapptemplateapi), and a [SwiftUI iOS app](https://github.com/nativeapptemplate/NativeAppTemplate-Free-iOS) — renamed and adapted for you, with validation built in.
+
 ## Overview
 
 NativeAppTemplate-Free-Android is configured to connect to `api.nativeapptemplate.com`.  


### PR DESCRIPTION
Adds a short pointer from this repo to **[nativeapptemplate-agent](https://github.com/nativeapptemplate/nativeapptemplate-agent)** — the Claude Code agent that generates a customized three-platform app (Rails 8.1 API + SwiftUI iOS + Jetpack Compose Android) from a one-sentence spec.

Closes a funnel gap: the agent README already points at this template, but this repo did not point back. Placed in the existing cross-link zone near the top, matching the sibling-repo links already there.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)